### PR TITLE
Launch the VS Code CMD file rather than the EXE

### DIFF
--- a/Guppi.Application/Commands/Notes/OpenNotesCommand.cs
+++ b/Guppi.Application/Commands/Notes/OpenNotesCommand.cs
@@ -43,7 +43,7 @@ namespace Guppi.Application.Commands.Notes
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
             string cmd = isWindows ?
-                         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Programs\Microsoft VS Code\Code.exe") :
+                         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Programs\Microsoft VS Code\bin\Code.cmd") :
                          "/usr/bin/code";
             string args = request.NoCreate ?
                 $"\"{configuration.NotesDirectory}\"" :

--- a/Guppi.Console/Guppi.Console.csproj
+++ b/Guppi.Console/Guppi.Console.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/rprouse/guppi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
     <PackageId>dotnet-guppi</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>guppi</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>


### PR DESCRIPTION
Fixes #58