### PR TITLE
Display ASCII charts

### DIFF
--- a/Guppi.Application/Extensions/AnsiConsoleHelper.cs
+++ b/Guppi.Application/Extensions/AnsiConsoleHelper.cs
@@ -19,5 +19,12 @@ namespace Guppi.Application.Extensions
             AnsiConsole.Render(rule);
             AnsiConsole.WriteLine();
         }
+
+        public static void PressEnterToContinue()
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[red][[Press ENTER to continue...]][/]");
+            System.Console.ReadLine();
+        }
     }
 }

--- a/Guppi.Application/Guppi.Application.csproj
+++ b/Guppi.Application/Guppi.Application.csproj
@@ -20,4 +20,11 @@
     <ProjectReference Include="..\Guppi.Domain\Guppi.Domain.csproj" />
   </ItemGroup>
 
+  <!-- Make Internals visible to the unit tests -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Guppi.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/Guppi.Application/Guppi.Application.csproj
+++ b/Guppi.Application/Guppi.Application.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.35.0" />
+    <PackageReference Include="Spectre.Console" Version="0.41.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
   </ItemGroup>

--- a/Guppi.Application/Queries/Ascii/AsciiQuery.cs
+++ b/Guppi.Application/Queries/Ascii/AsciiQuery.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Guppi.Domain.Entities.Ascii;
+using MediatR;
+
+namespace Guppi.Application.Queries.Ascii
+{
+    public sealed class AsciiQuery : IRequest<AsciiData[]>
+    {
+    }
+
+    internal sealed class AsciiQueryHandler : IRequestHandler<AsciiQuery, AsciiData[]>
+    {
+        public Task<AsciiData[]> Handle(AsciiQuery request, CancellationToken cancellationToken)
+        {
+            var result = new List<AsciiData>(128)
+            {
+                new AsciiData(0, "NUL", "Null"),
+                new AsciiData(1, "SOH", "Start of Header"),
+                new AsciiData(2, "STX", "Start of Text"),
+                new AsciiData(3, "ETX", "End of Text"),
+                new AsciiData(4, "EOT", "End of Transmission"),
+                new AsciiData(5, "ENQ", "Enquiry"),
+                new AsciiData(6, "ACK", "Acknowledge"),
+                new AsciiData(7, "BEL", "Bell"),
+                new AsciiData(8, "BS", "Backspace"),
+                new AsciiData(9, "HT", "Horizontal Tab"),
+                new AsciiData(10, "LF", "Line Feed"),
+                new AsciiData(11, "VT", "Vertical Tab"),
+                new AsciiData(12, "FF", "Form Feed"),
+                new AsciiData(13, "CR", "Carriage Return"),
+                new AsciiData(14, "SO", "Shift Out"),
+                new AsciiData(15, "SI", "Shift In"),
+                new AsciiData(16, "DLE", "Data Link Escape"),
+                new AsciiData(17, "DC1", "Device Control 1"),
+                new AsciiData(18, "DC2", "Device Control 2"),
+                new AsciiData(19, "DC3", "Device Control 3"),
+                new AsciiData(20, "DC4", "Device Control 4"),
+                new AsciiData(21, "NAK", "Negative Acknowledge"),
+                new AsciiData(22, "SYN", "Synchronize"),
+                new AsciiData(23, "ETB", "End of Transmission Block"),
+                new AsciiData(24, "CAN", "Cancel"),
+                new AsciiData(25, "EM", "End of Medium"),
+                new AsciiData(26, "SUB", "Substitute"),
+                new AsciiData(27, "ESC", "Escape"),
+                new AsciiData(28, "FS", "File Separator"),
+                new AsciiData(29, "GS", "Group Separator"),
+                new AsciiData(30, "RS", "Record Separator"),
+                new AsciiData(31, "US", "Unit Separator"),
+                new AsciiData(32, "SPACE", "Space")
+            };
+
+            for (char c = '!'; c <= '~'; c++)
+            {
+                result.Add(new AsciiData(c, $"{c}", ""));
+            }
+            result.Add(new AsciiData(127, "DEL", "Delete"));
+
+            return Task.FromResult(result.ToArray());
+        }
+    }
+}

--- a/Guppi.Application/Queries/Ascii/AsciiQuery.cs
+++ b/Guppi.Application/Queries/Ascii/AsciiQuery.cs
@@ -48,13 +48,62 @@ namespace Guppi.Application.Queries.Ascii
                 new AsciiData(29, "GS", "Group Separator"),
                 new AsciiData(30, "RS", "Record Separator"),
                 new AsciiData(31, "US", "Unit Separator"),
-                new AsciiData(32, "SPACE", "Space")
+                new AsciiData(32, "SPACE", "Space"),
+                new AsciiData(33, "!", "Exclamation Point"),
+                new AsciiData(34, "\"", "Double Quote"),
+                new AsciiData(35, "#", "Hash"),
+                new AsciiData(36, "$", "Dollar"),
+                new AsciiData(37, "%", "Percent"),
+                new AsciiData(38, "&", "Ampersand"),
+                new AsciiData(39, "'", "Single Quote"),
+                new AsciiData(40, "(", "Left Parenthesis"),
+                new AsciiData(41, ")", "Right Parenthesis"),
+                new AsciiData(42, "*", "Asterisk"),
+                new AsciiData(43, "+", "Plus"),
+                new AsciiData(44, ",", "Comma"),
+                new AsciiData(45, "-", "Minus"),
+                new AsciiData(46, ".", "Period"),
+                new AsciiData(47, "/", "Slash"),
             };
 
-            for (char c = '!'; c <= '~'; c++)
+            for (char c = '0'; c <= '9'; c++)
             {
                 result.Add(new AsciiData(c, $"{c}", ""));
             }
+
+            result.AddRange( new [] {
+                new AsciiData(58, ":", "Colon"),
+                new AsciiData(59, ";", "Semicolon"),
+                new AsciiData(60, "<", "Less Than"),
+                new AsciiData(61, "=", "Equals"),
+                new AsciiData(62, ">", "Greater Than"),
+                new AsciiData(63, "?", "Question Mark"),
+                new AsciiData(64, "@", "At Sign"),
+            });
+
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                result.Add(new AsciiData(c, $"{c}", ""));
+            }
+
+            result.AddRange(new[] {
+                new AsciiData(91, "[", "Left Square Bracket"),
+                new AsciiData(92, "\\", "Backslash"),
+                new AsciiData(93, "]", "Right Square Bracket"),
+                new AsciiData(94, "^", "Circumflex"),
+                new AsciiData(95, "_", "Underscore"),
+                new AsciiData(96, "`", "Grave/Accent"),
+            });
+
+            for (char c = 'a'; c <= 'z'; c++)
+            {
+                result.Add(new AsciiData(c, $"{c}", ""));
+            }
+
+            result.Add(new AsciiData(123, "{", "Left Curly Brace"));
+            result.Add(new AsciiData(124, "|", "Vertical Bar"));
+            result.Add(new AsciiData(125, "}", "Right Curly Brace"));
+            result.Add(new AsciiData(126, "~", "Tilde"));
             result.Add(new AsciiData(127, "DEL", "Delete"));
 
             return Task.FromResult(result.ToArray());

--- a/Guppi.Console/Guppi.Console.csproj
+++ b/Guppi.Console/Guppi.Console.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/rprouse/guppi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
     <PackageId>dotnet-guppi</PackageId>
-    <Version>2.6.2</Version>
+    <Version>2.7.0</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>guppi</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Spectre.Console" Version="0.35.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Spectre.Console" Version="0.41.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 

--- a/Guppi.Console/Program.cs
+++ b/Guppi.Console/Program.cs
@@ -15,6 +15,7 @@ static IServiceProvider ConfigureServices() =>
         .AddApplication()
         .AddInfrastructure()
         .AddTransient<ISkill, AdventOfCodeSkill>()
+        .AddTransient<ISkill, AsciiSkill>()
         .AddTransient<ISkill, CovidSkill>()
         .AddTransient<ISkill, CalendarSkill>()
         .AddTransient<ISkill, GitSkill>()

--- a/Guppi.Console/Skills/AsciiSkill.cs
+++ b/Guppi.Console/Skills/AsciiSkill.cs
@@ -34,30 +34,45 @@ namespace Guppi.Console.Skills
 
             AnsiConsoleHelper.TitleRule(":keyboard: ASCII Table");
 
+            DisplayCodes(data, 32, 0);
+
+            AnsiConsoleHelper.PressEnterToContinue();
+
+            DisplayCodes(data, 32, 64);
+
+            AnsiConsoleHelper.Rule("white");
+        }
+
+        private static void DisplayCodes(AsciiData[] data, int num, int offset)
+        {
             var table = new Table();
             table.Border = TableBorder.Minimal;
             table.AddColumns("Dec", "Hex", "HTML", "Char", "Description");
             table.AddColumns("Dec", "Hex", "HTML", "Char", "Description");
+            table.Columns[0].RightAligned();
+            table.Columns[2].RightAligned();
+            table.Columns[3].Centered();
+            table.Columns[5].RightAligned();
+            table.Columns[7].RightAligned();
+            table.Columns[8].Centered();
 
-            for (int i=0; i < 64; i++)
+            for (int i = offset; i < offset + num; i++)
             {
                 table.AddRow(
-                    data[i].Value.ToString(),
-                    $"0x{data[i].Value.ToString("X2")}",
-                    $"&#{data[i].Value};",
-                    data[i].Character.EscapeMarkup(),
+                    $"[cyan]{data[i].Value}[/]",
+                    $"[green]0x{data[i].Value.ToString("X2")}[/]",
+                    $"[yellow]&#{data[i].Value};[/]",
+                    $"[white]{data[i].Character.EscapeMarkup()}[/]",
                     data[i].Description,
 
-                    data[i+64].Value.ToString(),
-                    $"0x{data[i+64].Value.ToString("X2")}",
-                    $"&#{data[i+64].Value};",
-                    data[i+64].Character.EscapeMarkup(),
-                    data[i+64].Description
+                    $"[cyan]{data[i + num].Value}[/]",
+                    $"[green]0x{data[i + num].Value.ToString("X2")}[/]",
+                    $"[yellow]&#{data[i + num].Value};[/]",
+                    $"[white]{data[i + num].Character.EscapeMarkup()}[/]",
+                    data[i + num].Description
                     );
             }
-
             AnsiConsole.Render(table);
-            AnsiConsoleHelper.Rule("white");
         }
     }
 }

--- a/Guppi.Console/Skills/AsciiSkill.cs
+++ b/Guppi.Console/Skills/AsciiSkill.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using Guppi.Application.Extensions;
+using Guppi.Application.Queries.Ascii;
+using Guppi.Domain.Entities.Ascii;
+using MediatR;
+using Spectre.Console;
+
+namespace Guppi.Console.Skills
+{
+    public class AsciiSkill : ISkill
+    {
+        private readonly IMediator _mediator;
+
+        public AsciiSkill(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        public IEnumerable<Command> GetCommands() =>
+            new[]
+            {
+                new Command("ascii", "Views an ASCII chart.")
+                {
+                    Handler = CommandHandler.Create(async() => await ViewAsciiTable())
+                }
+            };
+
+        private async Task ViewAsciiTable()
+        {
+            AsciiData[] data = await _mediator.Send(new AsciiQuery());
+
+            AnsiConsoleHelper.TitleRule(":keyboard: ASCII Table");
+
+            var table = new Table();
+            table.Border = TableBorder.Minimal;
+            table.AddColumns("Dec", "Hex", "HTML", "Char", "Description");
+            table.AddColumns("Dec", "Hex", "HTML", "Char", "Description");
+
+            for (int i=0; i < 64; i++)
+            {
+                table.AddRow(
+                    data[i].Value.ToString(),
+                    $"0x{data[i].Value.ToString("X2")}",
+                    $"&#{data[i].Value};",
+                    data[i].Character.EscapeMarkup(),
+                    data[i].Description,
+
+                    data[i+64].Value.ToString(),
+                    $"0x{data[i+64].Value.ToString("X2")}",
+                    $"&#{data[i+64].Value};",
+                    data[i+64].Character.EscapeMarkup(),
+                    data[i+64].Description
+                    );
+            }
+
+            AnsiConsole.Render(table);
+            AnsiConsoleHelper.Rule("white");
+        }
+    }
+}

--- a/Guppi.Domain/Entities/Ascii/AsciiData.cs
+++ b/Guppi.Domain/Entities/Ascii/AsciiData.cs
@@ -1,0 +1,16 @@
+namespace Guppi.Domain.Entities.Ascii
+{
+    public struct AsciiData
+    {
+        public int Value { get; }
+        public string Character { get; }
+        public string Description { get; }
+
+        public AsciiData(int value, string character, string description)
+        {
+            Value = value;
+            Character = character;
+            Description = description;
+        }
+    }
+}

--- a/Guppi.Infrastructure/Guppi.Infrastructure.csproj
+++ b/Guppi.Infrastructure/Guppi.Infrastructure.csproj
@@ -9,16 +9,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.35.0" />
+    <PackageReference Include="Spectre.Console" Version="0.41.0" />
     <PackageReference Include="System.Speech" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
 
-    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.49.0.2087" />
+    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.55.0.2410" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Q42.HueApi" Version="3.15.8" />
-    <PackageReference Include="Q42.HueApi.ColorConverters" Version="3.14.0" />
+    <PackageReference Include="Q42.HueApi" Version="3.18.1" />
+    <PackageReference Include="Q42.HueApi.ColorConverters" Version="3.18.1" />
   </ItemGroup>
 
 </Project>

--- a/Guppi.Infrastructure/Services/Calendar/CalendarService.cs
+++ b/Guppi.Infrastructure/Services/Calendar/CalendarService.cs
@@ -35,7 +35,7 @@ namespace Guppi.Infrastructure.Services.Calendar
             {
                 string token = Configuration.GetConfigurationFile("calendar_token");
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
-                    GoogleClientSecrets.Load(stream).Secrets,
+                    GoogleClientSecrets.FromStream(stream).Secrets,
                     Scopes,
                     "user",
                     CancellationToken.None,

--- a/Guppi.Tests/Application/Queries/Ascii/AsciiQueryTests.cs
+++ b/Guppi.Tests/Application/Queries/Ascii/AsciiQueryTests.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Guppi.Application.Queries.Ascii;
+using NUnit.Framework;
+
+namespace Guppi.Tests.Application.Queries.Ascii
+{
+    [TestFixture]
+    public class AsciiQueryTests
+    {
+        AsciiQueryHandler handler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            handler = new AsciiQueryHandler();
+        }
+
+        [Test]
+        public async Task AsciiQueryHandler_Handle_Returns128Items()
+        {
+            var result = await handler
+                .Handle(new AsciiQuery(), new CancellationToken());
+
+            result.Should().NotBeNull().And.HaveCount(128);
+        }
+
+        [Test]
+        public async Task AsciiQueryHandler_Handle_ReturnsUniqueItems()
+        {
+            var result = await handler
+                .Handle(new AsciiQuery(), new CancellationToken());
+
+            for (int i = 0; i < 128; i++)
+            {
+                result.Should().Contain(a => a.Value == i);
+            }
+        }
+    }
+}

--- a/Guppi.Tests/Guppi.Tests.csproj
+++ b/Guppi.Tests/Guppi.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #70

- Update all NuGet packages
- Basic ASCII chart is now working
- Format the ASCII tables
- Add unit tests
