### PR TITLE
Fix light command line options

### DIFF
--- a/Guppi.Console/Guppi.Console.csproj
+++ b/Guppi.Console/Guppi.Console.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/rprouse/guppi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
     <PackageId>dotnet-guppi</PackageId>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>guppi</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Guppi.Console/Properties/launchSettings.json
+++ b/Guppi.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Guppi.Console": {
       "commandName": "Project",
-      "commandLineArgs": "lights list"
+      "commandLineArgs": "lights alert --light 1"
     }
   }
 }

--- a/Guppi.Console/Properties/launchSettings.json
+++ b/Guppi.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Guppi.Console": {
       "commandName": "Project",
-      "commandLineArgs": "lights alert --light 1"
+      "commandLineArgs": "lights set --light 1 --brightness 80"
     }
   }
 }

--- a/Guppi.Console/Skills/HueLightsSkill.cs
+++ b/Guppi.Console/Skills/HueLightsSkill.cs
@@ -41,6 +41,25 @@ namespace Guppi.Console.Skills
                 return defaultLight;
             };
 
+            ParseArgument<byte?> brightParser = (ArgumentResult result) =>
+            {
+                if (result.Tokens.Any())
+                {
+                    var value = result.Tokens.First().Value;
+                    if (byte.TryParse(value, out byte brightness))
+                    {
+                        return brightness;
+                    }
+                    result.ErrorMessage = $"Error: {value} is not a byte";
+                }
+                return null;
+            };
+
+            // Common options
+            var brightness = new Option<byte?>(new string[] { "--brightness", "-b" }, brightParser, description: "Set the brightness of a light, from 0 to 100 percent");
+            var color = new Option<string>(new string[] { "--color", "-c" }, "Color as a HEX color in the format FF0000 or #FF0000, or a common color name like red or blue");
+            var light = new Option<uint>(new string[] { "--light", "-l" }, lightParser, description: "The light to perform an action on. If unset, your default light or if 0 all lights");
+
             var bridges = new Command("bridges", "List bridges on the network");
             bridges.Handler = CommandHandler.Create(async () => await ListBridges());
 
@@ -57,32 +76,32 @@ namespace Guppi.Console.Skills
 
             var on = new Command("on", "Turn lights on")
             {
-                new Option<byte?>(new string[]{ "--brightness", "-b" }, "Set the brightness of a light, from 0 to 100 percent"),
-                new Option<string>(new string[]{ "--color", "-c" }, "Color as a HEX color in the format FF0000 or #FF0000, or a common color name like red or blue"),
-                new Option<uint>(new string[]{ "--light", "-l" }, lightParser, description: "The light to perform an action on. If unset, your default light or if 0 all lights"),
+                brightness,
+                color,
+                light,
             };
             on.Handler = CommandHandler.Create(async (string ip, byte? brightness, string color, uint light) => await Set(ip, true, false, false, brightness, color, light));
 
             var off = new Command("off", "Turn lights off")
             {
-                new Option<uint>(new string[]{ "--light", "-l" }, lightParser, description: "The light to perform an action on. If unset, your default light or if 0 all lights"),
+                light,
             };
             off.AddAlias("out");
             off.Handler = CommandHandler.Create(async (string ip, uint light) => await Set(ip, false, true, false, null, null, light));
 
             var alert = new Command("alert", "Set an alert on the lights")
             {
-                new Option<byte?>(new string[]{ "--brightness", "-b" }, "Set the brightness of a light, from 0 to 100 percent"),
-                new Option<string>(new string[]{ "--color", "-c" }, "Color as a HEX color in the format FF0000 or #FF0000, or a common color name like red or blue"),
-                new Option<uint>(new string[]{ "--light", "-l" }, lightParser, description: "The light to perform an action on. If unset, your default light or if 0 all lights"),
+                brightness,
+                color,
+                light,
             };
             alert.Handler = CommandHandler.Create(async (string ip, byte? brightness, string color, uint light) => await Set(ip, false, false, true, brightness, color, light));
 
             var set = new Command("set", "Sets the brightness and/or color to a light or lights")
             {
-                new Option<byte?>(new string[]{ "--brightness", "-b" }, "Set the brightness of a light, from 0 to 100 percent"),
-                new Option<string>(new string[]{ "--color", "-c" }, "Color as a HEX color in the format FF0000 or #FF0000, or a common color name like red or blue"),
-                new Option<uint>(new string[]{ "--light", "-l" }, lightParser, description: "The light to perform an action on. If unset, your default light or if 0 all lights"),
+                brightness,
+                color,
+                light,
             };
             set.Handler = CommandHandler.Create(async (string ip, byte? brightness, string color, uint light) => await Set(ip, false, false, false, brightness, color, light));
 


### PR DESCRIPTION
- Workaround for the inability to parse uint on the command line
- Fix the light brightness command line

Fixes #93