### PR TITLE
Show free time for a given day

### DIFF
--- a/Guppi.Console/Guppi.Console.csproj
+++ b/Guppi.Console/Guppi.Console.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/rprouse/guppi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
     <PackageId>dotnet-guppi</PackageId>
-    <Version>4.1.1</Version>
+    <Version>4.2.1</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>guppi</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Guppi.Console/Properties/launchSettings.json
+++ b/Guppi.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Guppi.Console": {
       "commandName": "Project",
-      "commandLineArgs": "thes tired"
+      "commandLineArgs": "cal free 2023-03-21"
     }
   }
 }

--- a/Guppi.Console/Skills/CalendarSkill.cs
+++ b/Guppi.Console/Skills/CalendarSkill.cs
@@ -185,13 +185,13 @@ internal class CalendarSkill : ISkill
                 end = new DateTime(date.Year, date.Month, date.Day, 17, 0, 0, DateTimeKind.Local);
                 foreach (var eventItem in events)
                 {
-                    if (eventItem.Start > lastEnd)
+                    if (eventItem.Start > lastEnd && eventItem.Start.Value.Subtract(lastEnd.Value).TotalMinutes >= 30)
                     {
                         freeTime.Add((lastEnd, eventItem.Start));
                     }
                     lastEnd = eventItem.End;
                 }
-                if (lastEnd < end)
+                if (lastEnd < end && end.Subtract(lastEnd.Value).TotalMinutes >= 30)
                 {
                     freeTime.Add((lastEnd, end));
                 }


### PR DESCRIPTION
Fixes #83

- Show free time for a given day
- Filter out free time less than 30 minutes
