### PR TITLE
Bump version to 9.0.1 and fix MCP STDIO logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Each feature follows a consistent pattern:
 - Optional: `Guppi.Core/Configurations/` for per-skill settings
 
 Skills are registered in `Program.cs` via DI as `ISkill` implementations.
+MCP tools are registered in `Guppi.MCP/Program.cs` via `.WithTools<T>()` on the MCP server builder.
 Services and providers are registered in `Guppi.Core/DependencyInjection.cs`.
 
 ## Key Dependencies
@@ -92,6 +93,15 @@ Per-skill configuration files are stored as JSON in:
 - Windows: `%LOCALAPPDATA%\Guppi\`
 - Pattern: `Configuration.Load<T>(name)` / `Configuration.Save()`
 
+## Adding a New Feature
+
+1. Create `Guppi.Core/Interfaces/Services/I{Name}Service.cs` — service contract
+2. Create `Guppi.Core/Services/{Name}Service.cs` — implements the service
+3. Register the service in `Guppi.Core/DependencyInjection.cs`
+4. **For CLI:** Create `Guppi.Console/Skills/{Name}Skill.cs` implementing `ISkill`, register in `Guppi.Console/Program.cs`
+5. **For MCP:** Create `Guppi.MCP/Tools/{Name}Tools.cs` with `[McpServerTool]` attributes, register via `.WithTools<{Name}Tools>()` in `Guppi.MCP/Program.cs`
+6. Optional: Add `Guppi.Core/Providers/` for external integrations, `Guppi.Core/Configurations/` for settings
+
 ## Gotchas
 
 - The `dotnet-todo` directory is a **git submodule** — clone with `--recurse-submodules` or run `git submodule update --init`
@@ -101,3 +111,4 @@ Per-skill configuration files are stored as JSON in:
 - CI runs on `ubuntu-latest` but the app targets Windows features (System.Speech, System.Management)
 - NuGet packages are published to **GitHub Packages** on merge to main — two packages: `dotnet-guppi` (CLI) and `dotnet-guppi-mcp` (MCP server)
 - The solution uses the new `.slnx` format (not `.sln`)
+- **MCP STDIO transport:** Never log to stdout in `Guppi.MCP` — it corrupts the JSON-RPC protocol. All logging must go to stderr (configured via `LogToStandardErrorThreshold`)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>9.1.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Rob Prouse</Authors>
     <Company>Alteridem Consulting</Company>
     <Copyright>Copyright (c) 2025-2026 Rob Prouse</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.1.0</Version>
     <Authors>Rob Prouse</Authors>
     <Company>Alteridem Consulting</Company>
     <Copyright>Copyright (c) 2025-2026 Rob Prouse</Copyright>

--- a/Guppi.MCP/Program.cs
+++ b/Guppi.MCP/Program.cs
@@ -2,9 +2,13 @@ using Guppi.Core;
 using Guppi.MCP.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
 
 builder.Services
     .AddCore()


### PR DESCRIPTION
## Summary
- Increment minor version from 9.0.0 to 9.0.1 in `Directory.Build.props`
- Fix MCP server logging corrupting STDIO transport by redirecting all log output from stdout to stderr

## Test plan
- [ ] Verify `dotnet build` succeeds
- [ ] Verify MCP server connects successfully over STDIO without log noise on stdout
- [ ] Verify version displays as 9.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 9.1.0

* **Improvements**
  * Enhanced logging configuration for better diagnostic output capture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->