### PR TITLE
Add Philips Hue light control tools to MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,11 @@ Per-skill configuration files are stored as JSON in:
 - NuGet packages are published to **GitHub Packages** on merge to main — two packages: `dotnet-guppi` (CLI) and `dotnet-guppi-mcp` (MCP server)
 - The solution uses the new `.slnx` format (not `.sln`)
 - **MCP STDIO transport:** Never log to stdout in `Guppi.MCP` — it corrupts the JSON-RPC protocol. All logging must go to stderr (configured via `LogToStandardErrorThreshold`)
+
+## Workflow
+
+- **Always work on a branch** — never commit directly to `main`. Create a feature branch (e.g., `feature/hue-mcp-tools`) before making changes.
+- **Version updates** — update the version in `Directory.Build.props` using semantic versioning:
+  - **Major** (X.0.0): breaking changes to existing commands, services, or MCP tool contracts
+  - **Minor** (x.Y.0): new features — new skills, MCP tools, services, or commands
+  - **Patch** (x.y.Z): bug fixes, documentation updates, refactoring with no behavior change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,17 @@ Services and providers are registered in `Guppi.Core/DependencyInjection.cs`.
 - **ModelContextProtocol** (1.1.0) — MCP server SDK (STDIO + HTTP transports)
 - **Notable Core dependencies:** LibGit2Sharp (Git operations), Google.Apis.Calendar/Tasks (Google integration), Q42.HueApi (Philips Hue), OpenAI (AI features), Microsoft.Playwright (web scraping), ClosedXML (Excel), System.IO.Ports (serial)
 
+## MCP Tool Return Types
+
+The `[McpServerTool]` method return type determines how the MCP SDK serializes the response:
+
+- `string` → returned as a `TextContentBlock`
+- Any other object → auto-serialized to JSON as text content
+- `IEnumerable<ContentBlock>` → returned directly as content blocks
+- `CallToolResult` → returned as-is for full control over the response
+
+For tools that can return either structured data (success) or an error message (failure), use `Task<object>` as the return type. Return domain entities on success (auto-serialized to JSON) and a descriptive `string` on error.
+
 ## Code Style
 
 Conventions from `.editorconfig` (follows NUnit coding standards):

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.1.0</Version>
     <Authors>Rob Prouse</Authors>
     <Company>Alteridem Consulting</Company>
     <Copyright>Copyright (c) 2025-2026 Rob Prouse</Copyright>

--- a/Guppi.MCP/Program.cs
+++ b/Guppi.MCP/Program.cs
@@ -14,6 +14,7 @@ builder.Services
     .AddCore()
     .AddMcpServer()
     .WithStdioServerTransport()
-    .WithTools<UtilitiesTools>();
+    .WithTools<UtilitiesTools>()
+    .WithTools<HueLightsTools>();
 
 await builder.Build().RunAsync();

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -133,5 +133,43 @@ namespace Guppi.MCP.Tools
                 return $"Error: {ex.Message}";
             }
         }
+
+        [McpServerTool, Description("Triggers an alert flash on a Philips Hue light")]
+        public async Task<object> AlertHueLight(
+            [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+            [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+            [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+            [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+        {
+            try
+            {
+                uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+                var command = new SetLightCommand
+                {
+                    IpAddress = ip,
+                    On = false,
+                    Off = false,
+                    Alert = true,
+                    Brightness = brightness,
+                    Color = color,
+                    Light = targetLight,
+                    WaitForUserInput = _ => { }
+                };
+                await _service.SetLight(command);
+                return await _service.ListLights(ip, _ => { });
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
     }
 }

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -171,5 +171,43 @@ namespace Guppi.MCP.Tools
                 return $"Error: {ex.Message}";
             }
         }
+
+        [McpServerTool, Description("Sets the brightness and/or color of a Philips Hue light without changing its on/off state")]
+        public async Task<object> SetHueLight(
+            [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+            [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+            [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+            [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+        {
+            try
+            {
+                uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+                var command = new SetLightCommand
+                {
+                    IpAddress = ip,
+                    On = false,
+                    Off = false,
+                    Alert = false,
+                    Brightness = brightness,
+                    Color = color,
+                    Light = targetLight,
+                    WaitForUserInput = _ => { }
+                };
+                await _service.SetLight(command);
+                return await _service.ListLights(ip, _ => { });
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
     }
 }

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -38,5 +38,27 @@ namespace Guppi.MCP.Tools
                 return $"Error: {ex.Message}";
             }
         }
+
+        [McpServerTool, Description("Lists all Philips Hue lights and their current state (on/off, brightness, color)")]
+        public async Task<object> ListHueLights(
+            [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null)
+        {
+            try
+            {
+                return await _service.ListLights(ip, _ => { });
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
     }
 }

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -99,5 +99,39 @@ namespace Guppi.MCP.Tools
                 return $"Error: {ex.Message}";
             }
         }
+
+        [McpServerTool, Description("Turns off a Philips Hue light")]
+        public async Task<object> TurnOffHueLight(
+            [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+            [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0)
+        {
+            try
+            {
+                uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+                var command = new SetLightCommand
+                {
+                    IpAddress = ip,
+                    On = false,
+                    Off = true,
+                    Alert = false,
+                    Light = targetLight,
+                    WaitForUserInput = _ => { }
+                };
+                await _service.SetLight(command);
+                return await _service.ListLights(ip, _ => { });
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
     }
 }

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using Guppi.Core.Entities.Hue;
 using Guppi.Core.Interfaces.Services;
+using Guppi.Core.Services.Hue;
 using ModelContextProtocol.Server;
 
 namespace Guppi.MCP.Tools
@@ -45,6 +46,44 @@ namespace Guppi.MCP.Tools
         {
             try
             {
+                return await _service.ListLights(ip, _ => { });
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
+
+        [McpServerTool, Description("Turns on a Philips Hue light with optional brightness and color")]
+        public async Task<object> TurnOnHueLight(
+            [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+            [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+            [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+            [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+        {
+            try
+            {
+                uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+                var command = new SetLightCommand
+                {
+                    IpAddress = ip,
+                    On = true,
+                    Off = false,
+                    Alert = false,
+                    Brightness = brightness,
+                    Color = color,
+                    Light = targetLight,
+                    WaitForUserInput = _ => { }
+                };
+                await _service.SetLight(command);
                 return await _service.ListLights(ip, _ => { });
             }
             catch (ArgumentException)

--- a/Guppi.MCP/Tools/HueLightsTools.cs
+++ b/Guppi.MCP/Tools/HueLightsTools.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Guppi.Core.Entities.Hue;
+using Guppi.Core.Interfaces.Services;
+using ModelContextProtocol.Server;
+
+namespace Guppi.MCP.Tools
+{
+    [McpServerToolType]
+    public class HueLightsTools
+    {
+        private readonly IHueLightService _service;
+
+        public HueLightsTools(IHueLightService service)
+        {
+            _service = service;
+        }
+
+        [McpServerTool, Description("Lists Philips Hue bridges found on the local network")]
+        public async Task<object> ListHueBridges()
+        {
+            try
+            {
+                return await _service.ListBridges();
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-03-24-hue-mcp-tools-plan.md
+++ b/docs/superpowers/plans/2026-03-24-hue-mcp-tools-plan.md
@@ -95,7 +95,7 @@ git commit -m "feat: add HueLightsTools with ListHueBridges MCP tool"
 
 - [ ] **Step 1: Add ListHueLights method**
 
-Add this method to the `HueLightsTools` class. Note the `light == 0` default resolution and the no-op `WaitForUserInput` lambda:
+Add this method to the `HueLightsTools` class. Note the no-op `WaitForUserInput` lambda passed as the second argument to `ListLights`:
 
 ```csharp
 [McpServerTool, Description("Lists all Philips Hue lights and their current state (on/off, brightness, color)")]

--- a/docs/superpowers/plans/2026-03-24-hue-mcp-tools-plan.md
+++ b/docs/superpowers/plans/2026-03-24-hue-mcp-tools-plan.md
@@ -1,0 +1,458 @@
+# Hue MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add six Philips Hue light control tools to the Guppi MCP server, reusing the existing `IHueLightService`.
+
+**Architecture:** A single `HueLightsTools` class with non-static instance methods receives `IHueLightService` via constructor injection. Each tool method wraps a service call with error handling, returning domain entities on success or error strings on failure.
+
+**Tech Stack:** .NET 10, ModelContextProtocol SDK 1.1.0, NUnit 4, FluentAssertions 8
+
+**Spec:** `docs/superpowers/specs/2026-03-24-hue-mcp-tools-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `Guppi.MCP/Tools/HueLightsTools.cs` | Create | Six MCP tool methods for Hue light control |
+| `Guppi.MCP/Program.cs` | Modify | Append `.WithTools<HueLightsTools>()` to the builder chain |
+| `AGENTS.md` | Modify | Add MCP SDK return types section after `## Key Dependencies`, before `## Code Style` |
+
+---
+
+### Task 1: Create HueLightsTools with ListHueBridges
+
+**Files:**
+- Create: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Create HueLightsTools class with constructor and ListHueBridges**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Guppi.Core.Entities.Hue;
+using Guppi.Core.Interfaces.Services;
+using ModelContextProtocol.Server;
+
+namespace Guppi.MCP.Tools
+{
+    [McpServerToolType]
+    public class HueLightsTools
+    {
+        private readonly IHueLightService _service;
+
+        public HueLightsTools(IHueLightService service)
+        {
+            _service = service;
+        }
+
+        [McpServerTool, Description("Lists Philips Hue bridges found on the local network")]
+        public async Task<object> ListHueBridges()
+        {
+            try
+            {
+                return await _service.ListBridges();
+            }
+            catch (ArgumentException)
+            {
+                return "Error: Hue Bridge not found";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+            }
+            catch (Exception ex)
+            {
+                return $"Error: {ex.Message}";
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add HueLightsTools with ListHueBridges MCP tool"
+```
+
+---
+
+### Task 2: Add ListHueLights tool
+
+**Files:**
+- Modify: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Add ListHueLights method**
+
+Add this method to the `HueLightsTools` class. Note the `light == 0` default resolution and the no-op `WaitForUserInput` lambda:
+
+```csharp
+[McpServerTool, Description("Lists all Philips Hue lights and their current state (on/off, brightness, color)")]
+public async Task<object> ListHueLights(
+    [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null)
+{
+    try
+    {
+        return await _service.ListLights(ip, _ => { });
+    }
+    catch (ArgumentException)
+    {
+        return "Error: Hue Bridge not found";
+    }
+    catch (InvalidOperationException)
+    {
+        return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+    }
+    catch (Exception ex)
+    {
+        return $"Error: {ex.Message}";
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add ListHueLights MCP tool"
+```
+
+---
+
+### Task 3: Add TurnOnHueLight tool
+
+**Files:**
+- Modify: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Add the using directive and TurnOnHueLight method**
+
+Add `using Guppi.Core.Services.Hue;` to the top of the file.
+
+Add this method to the class:
+
+```csharp
+[McpServerTool, Description("Turns on a Philips Hue light with optional brightness and color")]
+public async Task<object> TurnOnHueLight(
+    [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+    [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+    [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+    [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+{
+    try
+    {
+        uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+        var command = new SetLightCommand
+        {
+            IpAddress = ip,
+            On = true,
+            Off = false,
+            Alert = false,
+            Brightness = brightness,
+            Color = color,
+            Light = targetLight,
+            WaitForUserInput = _ => { }
+        };
+        await _service.SetLight(command);
+        return await _service.ListLights(ip, _ => { });
+    }
+    catch (ArgumentException)
+    {
+        return "Error: Hue Bridge not found";
+    }
+    catch (InvalidOperationException)
+    {
+        return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+    }
+    catch (Exception ex)
+    {
+        return $"Error: {ex.Message}";
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add TurnOnHueLight MCP tool"
+```
+
+---
+
+### Task 4: Add TurnOffHueLight tool
+
+**Files:**
+- Modify: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Add TurnOffHueLight method**
+
+```csharp
+[McpServerTool, Description("Turns off a Philips Hue light")]
+public async Task<object> TurnOffHueLight(
+    [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+    [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0)
+{
+    try
+    {
+        uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+        var command = new SetLightCommand
+        {
+            IpAddress = ip,
+            On = false,
+            Off = true,
+            Alert = false,
+            Light = targetLight,
+            WaitForUserInput = _ => { }
+        };
+        await _service.SetLight(command);
+        return await _service.ListLights(ip, _ => { });
+    }
+    catch (ArgumentException)
+    {
+        return "Error: Hue Bridge not found";
+    }
+    catch (InvalidOperationException)
+    {
+        return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+    }
+    catch (Exception ex)
+    {
+        return $"Error: {ex.Message}";
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add TurnOffHueLight MCP tool"
+```
+
+---
+
+### Task 5: Add AlertHueLight tool
+
+**Files:**
+- Modify: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Add AlertHueLight method**
+
+```csharp
+[McpServerTool, Description("Triggers an alert flash on a Philips Hue light")]
+public async Task<object> AlertHueLight(
+    [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+    [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+    [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+    [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+{
+    try
+    {
+        uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+        var command = new SetLightCommand
+        {
+            IpAddress = ip,
+            On = false,
+            Off = false,
+            Alert = true,
+            Brightness = brightness,
+            Color = color,
+            Light = targetLight,
+            WaitForUserInput = _ => { }
+        };
+        await _service.SetLight(command);
+        return await _service.ListLights(ip, _ => { });
+    }
+    catch (ArgumentException)
+    {
+        return "Error: Hue Bridge not found";
+    }
+    catch (InvalidOperationException)
+    {
+        return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+    }
+    catch (Exception ex)
+    {
+        return $"Error: {ex.Message}";
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add AlertHueLight MCP tool"
+```
+
+---
+
+### Task 6: Add SetHueLight tool
+
+**Files:**
+- Modify: `Guppi.MCP/Tools/HueLightsTools.cs`
+
+- [ ] **Step 1: Add SetHueLight method**
+
+```csharp
+[McpServerTool, Description("Sets the brightness and/or color of a Philips Hue light without changing its on/off state")]
+public async Task<object> SetHueLight(
+    [Description("IP address of the Hue Bridge. Leave empty to auto-discover.")] string ip = null,
+    [Description("Light ID to target. 0 for all lights. Leave empty for default light.")] uint light = 0,
+    [Description("Brightness percentage, 0-100.")] byte? brightness = null,
+    [Description("Color as hex (FF0000 or #FF0000) or named color (red, blue).")] string color = null)
+{
+    try
+    {
+        uint targetLight = light == 0 ? _service.GetDefaultLight() : light;
+        var command = new SetLightCommand
+        {
+            IpAddress = ip,
+            On = false,
+            Off = false,
+            Alert = false,
+            Brightness = brightness,
+            Color = color,
+            Light = targetLight,
+            WaitForUserInput = _ => { }
+        };
+        await _service.SetLight(command);
+        return await _service.ListLights(ip, _ => { });
+    }
+    catch (ArgumentException)
+    {
+        return "Error: Hue Bridge not found";
+    }
+    catch (InvalidOperationException)
+    {
+        return "Error: Not registered with bridge. Run 'guppi hue register' from the CLI first.";
+    }
+    catch (Exception ex)
+    {
+        return $"Error: {ex.Message}";
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Guppi.MCP/Guppi.MCP.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Tools/HueLightsTools.cs
+git commit -m "feat: add SetHueLight MCP tool"
+```
+
+---
+
+### Task 7: Register HueLightsTools in MCP Program.cs
+
+**Files:**
+- Modify: `Guppi.MCP/Program.cs`
+
+- [ ] **Step 1: Append `.WithTools<HueLightsTools>()` to the builder chain**
+
+In `Guppi.MCP/Program.cs`, find the line `.WithTools<UtilitiesTools>();` and replace it with:
+
+```csharp
+    .WithTools<UtilitiesTools>()
+    .WithTools<HueLightsTools>();
+```
+
+This is an append-only edit — change the `;` to a method chain continuation and add the new line.
+
+- [ ] **Step 2: Build the full solution to verify everything wires up**
+
+Run: `dotnet build`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Guppi.MCP/Program.cs
+git commit -m "feat: register HueLightsTools in MCP server"
+```
+
+---
+
+### Task 8: Update AGENTS.md with MCP SDK return type docs
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Add MCP tool return types section**
+
+Insert a new section after `## Key Dependencies` (after its bullet list ends) and before `## Code Style`. Add:
+
+```markdown
+## MCP Tool Return Types
+
+The `[McpServerTool]` method return type determines how the MCP SDK serializes the response:
+
+- `string` → returned as a `TextContentBlock`
+- Any other object → auto-serialized to JSON as text content
+- `IEnumerable<ContentBlock>` → returned directly as content blocks
+- `CallToolResult` → returned as-is for full control over the response
+
+For tools that can return either structured data (success) or an error message (failure), use `Task<object>` as the return type. Return domain entities on success (auto-serialized to JSON) and a descriptive `string` on error.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: add MCP SDK return type documentation to AGENTS.md"
+```
+
+---
+
+### Task 9: Final build and test verification
+
+- [ ] **Step 1: Run full solution build**
+
+Run: `dotnet build`
+Expected: Build succeeded with no warnings in `Guppi.MCP`
+
+- [ ] **Step 2: Run all tests**
+
+Run: `dotnet test --no-restore --verbosity normal`
+Expected: All tests pass (existing tests should not be affected)
+
+- [ ] **Step 3: Verify MCP server starts without errors**
+
+Run: `dotnet run --project Guppi.MCP/Guppi.MCP.csproj`
+Expected: Server starts and waits for STDIO input (Ctrl+C to stop). No errors on stderr.

--- a/docs/superpowers/specs/2026-03-24-hue-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-03-24-hue-mcp-tools-design.md
@@ -6,7 +6,7 @@ Add Philips Hue light control tools to the Guppi MCP server (`Guppi.MCP`), expos
 
 ## Tools
 
-Six tools in a single `HueLightsTools` class:
+Six **non-static instance methods** in a single `HueLightsTools` class (unlike `UtilitiesTools` which uses static methods, because constructor injection is required):
 
 | Tool | Parameters | Returns | Description |
 |------|-----------|---------|-------------|
@@ -20,18 +20,23 @@ Six tools in a single `HueLightsTools` class:
 ### Parameters
 
 - **`ip`** (`string?`): IP address of the Hue Bridge. Defaults to auto-discovering the first bridge on the network.
-- **`light`** (`uint`): The light ID to target. Defaults to the user's configured default light. `0` targets all lights.
+- **`light`** (`uint`): The light ID to target. `0` targets all lights. The C# parameter defaults to `0`, but inside each tool method body, if `light == 0`, call `_service.GetDefaultLight()` to resolve the user's configured default. This mirrors the CLI skill's behavior where the default is resolved at runtime, not as a compile-time constant.
 - **`brightness`** (`byte?`): Brightness as a percentage, 0–100.
 - **`color`** (`string?`): Color as hex (`FF0000` or `#FF0000`) or a named color (`red`, `blue`).
 
 ### Return Values
 
-- **Success:** Returns domain entity objects (`HueBridge`, `HueLight`) which the MCP SDK auto-serializes to JSON.
-- **Action tools** (on/off/alert/set): After executing the action, call `ListLights` to return the updated light states as confirmation.
+Tool method signatures return `Task<object>` to accommodate both success and error cases:
+
+- **Success:** Returns domain entity objects (`IEnumerable<HueBridge>`, `IEnumerable<HueLight>`) which the MCP SDK auto-serializes to JSON.
+- **Action tools** (on/off/alert/set): After executing the action, call `_service.ListLights()` to return the updated light states as confirmation.
+- **Error:** Returns a `string` with a descriptive message (rendered as text content by the SDK).
+
+The MCP SDK handles both cases — objects are serialized to JSON, strings become text content.
 
 ### Error Handling
 
-All exceptions are caught and returned as descriptive `string` values (rendered as text content by the SDK):
+All exceptions are caught and returned as descriptive `string` values:
 
 - Bridge not found: `"Error: Hue Bridge not found"`
 - Not registered: `"Error: Not registered with bridge. Run 'guppi hue register' from the CLI first."`
@@ -45,7 +50,12 @@ If a tool is called and the bridge is not registered, the error message directs 
 
 ## WaitForUserInput Handling
 
-The `IHueLightService.ListLights()` and `SetLight()` methods accept an `Action<string>` callback used during auto-registration. MCP tools pass a no-op lambda `(_ => { })`. If registration is actually needed, the provider throws `InvalidOperationException`, which is caught and returned as the registration error message.
+The `IHueLightService.ListLights()` and `SetLight()` methods accept an `Action<string>` callback used during auto-registration. MCP tools pass a no-op lambda `(_ => { })` to every service call that requires it:
+
+- `_service.ListLights(ip, _ => { })` — the second parameter is the callback
+- `SetLightCommand.WaitForUserInput = _ => { }` — must be set on the command object
+
+If registration is actually needed during these calls, the provider will throw `InvalidOperationException`, which is caught and returned as the registration error message.
 
 ## DI & Wiring
 

--- a/docs/superpowers/specs/2026-03-24-hue-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-03-24-hue-mcp-tools-design.md
@@ -1,0 +1,78 @@
+# Hue MCP Tools Design
+
+## Summary
+
+Add Philips Hue light control tools to the Guppi MCP server (`Guppi.MCP`), exposing the existing `IHueLightService` functionality as six MCP tools. This follows the established pattern of CLI skills and MCP tools sharing the same service layer.
+
+## Tools
+
+Six tools in a single `HueLightsTools` class:
+
+| Tool | Parameters | Returns | Description |
+|------|-----------|---------|-------------|
+| `ListHueBridges` | — | `IEnumerable<HueBridge>` | Lists Hue bridges found on the network |
+| `ListHueLights` | `ip?` | `IEnumerable<HueLight>` | Lists all lights and their current state |
+| `TurnOnHueLight` | `ip?`, `light?`, `brightness?`, `color?` | `IEnumerable<HueLight>` | Turns on a light with optional brightness/color |
+| `TurnOffHueLight` | `ip?`, `light?` | `IEnumerable<HueLight>` | Turns off a light |
+| `AlertHueLight` | `ip?`, `light?`, `brightness?`, `color?` | `IEnumerable<HueLight>` | Triggers an alert flash on a light |
+| `SetHueLight` | `ip?`, `light?`, `brightness?`, `color?` | `IEnumerable<HueLight>` | Sets brightness/color without changing on/off state |
+
+### Parameters
+
+- **`ip`** (`string?`): IP address of the Hue Bridge. Defaults to auto-discovering the first bridge on the network.
+- **`light`** (`uint`): The light ID to target. Defaults to the user's configured default light. `0` targets all lights.
+- **`brightness`** (`byte?`): Brightness as a percentage, 0–100.
+- **`color`** (`string?`): Color as hex (`FF0000` or `#FF0000`) or a named color (`red`, `blue`).
+
+### Return Values
+
+- **Success:** Returns domain entity objects (`HueBridge`, `HueLight`) which the MCP SDK auto-serializes to JSON.
+- **Action tools** (on/off/alert/set): After executing the action, call `ListLights` to return the updated light states as confirmation.
+
+### Error Handling
+
+All exceptions are caught and returned as descriptive `string` values (rendered as text content by the SDK):
+
+- Bridge not found: `"Error: Hue Bridge not found"`
+- Not registered: `"Error: Not registered with bridge. Run 'guppi hue register' from the CLI first."`
+- Other: `"Error: {exception.Message}"`
+
+## Registration & Bridge Pairing
+
+The `Register` and `Configure` commands from the CLI skill are **not** exposed as MCP tools. Bridge registration requires the user to physically press a button on the Hue bridge, which is interactive and not suitable for MCP.
+
+If a tool is called and the bridge is not registered, the error message directs the user to run `guppi hue register` from the CLI.
+
+## WaitForUserInput Handling
+
+The `IHueLightService.ListLights()` and `SetLight()` methods accept an `Action<string>` callback used during auto-registration. MCP tools pass a no-op lambda `(_ => { })`. If registration is actually needed, the provider throws `InvalidOperationException`, which is caught and returned as the registration error message.
+
+## DI & Wiring
+
+- `HueLightsTools` receives `IHueLightService` via constructor injection (supported by MCP SDK).
+- `IHueLightService` and `IHueProvider` are already registered in `Guppi.Core/DependencyInjection.cs`.
+- Registration in `Guppi.MCP/Program.cs`: add `.WithTools<HueLightsTools>()` to the builder chain.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Guppi.MCP/Tools/HueLightsTools.cs` | **New** — six MCP tool methods |
+| `Guppi.MCP/Program.cs` | Add `.WithTools<HueLightsTools>()` |
+| `AGENTS.md` | Add MCP SDK return type documentation |
+
+## AGENTS.md Update
+
+Add documentation about MCP SDK supported return types to the existing MCP/architecture section:
+
+- `string` → `TextContentBlock`
+- Any other object → auto-serialized to JSON as text content
+- `IEnumerable<ContentBlock>` → returned directly
+- `CallToolResult` → returned as-is for full control
+- On error, return a `string` with a descriptive message
+
+## No Changes To
+
+- `Guppi.Core` — service, provider, entities, configurations remain as-is
+- `Guppi.Console` — CLI skill unchanged
+- `Guppi.Core/DependencyInjection.cs` — already registers all needed types


### PR DESCRIPTION
## Summary

- Add six MCP tools for Philips Hue light control: `ListHueBridges`, `ListHueLights`, `TurnOnHueLight`, `TurnOffHueLight`, `AlertHueLight`, `SetHueLight`
- Tools reuse the existing `IHueLightService` via constructor injection
- Document MCP SDK return types and add workflow guidance (branch-first, semantic versioning) to AGENTS.md
- Bump version to 9.1.0

## Details

New file `Guppi.MCP/Tools/HueLightsTools.cs` with six non-static tool methods that wrap `IHueLightService`. Success returns domain entities (`HueBridge`, `HueLight`) auto-serialized to JSON by the MCP SDK. Errors return descriptive strings. Bridge registration is not exposed as an MCP tool (requires physical button press) — unregistered bridges get a helpful error directing users to `guppi hue register`.

## Test plan

- [x] Full solution builds with 0 errors and 0 warnings
- [x] All 128 existing tests pass
- [ ] Manual: start MCP server (`dotnet run --project Guppi.MCP`), verify tools appear in tool listing
- [ ] Manual: test `ListHueBridges` and `ListHueLights` against a live Hue bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Philips Hue light control: discover bridges and lights, toggle lights on/off, trigger alerts, and adjust brightness and color settings.

* **Documentation**
  * Enhanced developer documentation with MCP tool return type guidance and workflow standards.
  * Added design specifications and implementation plans for new features.

* **Chores**
  * Version updated to 9.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->