### PR TITLE
Add experimental Repl pilot for shared CLI, REPL, and MCP graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,18 +14,24 @@ dotnet test --no-restore --verbosity normal
 # Pack as dotnet tools
 dotnet pack Guppi.Console/Guppi.Console.csproj --configuration Release
 dotnet pack Guppi.MCP/Guppi.MCP.csproj --configuration Release
+dotnet pack Guppi.Repl/Guppi.Repl.csproj --configuration Release
 
 # Install locally (from solution root)
 dotnet tool install -g --add-source ./Guppi.Console/nupkg dotnet-guppi
 dotnet tool install -g --add-source ./Guppi.MCP/nupkg dotnet-guppi-mcp
+dotnet tool install -g --add-source ./Guppi.Repl/nupkg dotnet-guppi-repl
 
 # Update local install
 dotnet tool update -g --add-source ./Guppi.Console/nupkg dotnet-guppi
 dotnet tool update -g --add-source ./Guppi.MCP/nupkg dotnet-guppi-mcp
+dotnet tool update -g --add-source ./Guppi.Repl/nupkg dotnet-guppi-repl
 
 # Run
 guppi <skill> <command> [options]
-guppi.mcp  # Starts the MCP server (STDIO)
+guppi.mcp  # Starts the existing MCP server (STDIO)
+guppi.repl <context> <command> [options]  # Experimental one-shot CLI
+guppi.repl                              # Experimental interactive REPL
+guppi.repl mcp serve                    # Experimental graph over MCP STDIO
 ```
 
 ## Architecture
@@ -41,16 +47,22 @@ Guppi.Core/             # Business logic, no CLI dependencies
   Configurations/       # Per-skill configuration classes
   Entities/             # Domain models
   Extensions/           # Helper extension methods
-Guppi.MCP/              # MCP server entry point (STDIO transport)
+Guppi.MCP/              # Existing MCP server entry point (STDIO transport)
   Tools/                # MCP tool classes (attribute-based)
   Program.cs            # DI composition root
-Guppi.Tests/            # NUnit tests
+Guppi.Repl/             # Experimental shared Repl graph (CLI + REPL + MCP)
+  Skills/               # IReplModule definitions for pilot contexts
+  Results/              # Stable typed result records
+  GuppiReplApp.cs       # Shared composition root and MCP allow-list
+Guppi.Repl.Tests/       # Repl.Testing graph tests and interactive integration tests
+Guppi.Tests/            # Existing NUnit tests
 dotnet-todo/            # Git submodule - todo.txt library
 ```
 
 **Layer flow:**
 - `Skill` (Console) -> `IService` -> `IProvider` (Core)
 - `Tool` (MCP) -> `IService` -> `IProvider` (Core)
+- `IReplModule` (pilot) -> `IService`/injected adapter -> `IProvider` (Core), exposed through one graph
 
 Each feature follows a consistent pattern:
 - `Guppi.Console/Skills/{Name}Skill.cs` — defines CLI commands via `ISkill.GetCommands()`
@@ -71,7 +83,8 @@ Services and providers are registered in `Guppi.Core/DependencyInjection.cs`.
 - **Microsoft.Extensions.DependencyInjection** — DI container
 - **NUnit 4** + **FluentAssertions 8** — testing
 - **dotnet-todo** — git submodule, must be checked out (`git submodule update --init`)
-- **ModelContextProtocol** (1.1.0) — MCP server SDK (STDIO + HTTP transports)
+- **ModelContextProtocol** (1.1.0) — existing MCP server SDK (STDIO + HTTP transports)
+- **Repl / Repl.Mcp / Repl.Spectre / Repl.Testing** (0.11.0-dev.181, pinned prerelease) — experimental shared graph
 - **Notable Core dependencies:** LibGit2Sharp (Git operations), Google.Apis.Calendar/Tasks (Google integration), Q42.HueApi (Philips Hue), OpenAI (AI features), Microsoft.Playwright (web scraping), ClosedXML (Excel), System.IO.Ports (serial)
 
 ## MCP Tool Return Types
@@ -111,7 +124,8 @@ Per-skill configuration files are stored as JSON in:
 3. Register the service in `Guppi.Core/DependencyInjection.cs`
 4. **For CLI:** Create `Guppi.Console/Skills/{Name}Skill.cs` implementing `ISkill`, register in `Guppi.Console/Program.cs`
 5. **For MCP:** Create `Guppi.MCP/Tools/{Name}Tools.cs` with `[McpServerTool]` attributes, register via `.WithTools<{Name}Tools>()` in `Guppi.MCP/Program.cs`
-6. Optional: Add `Guppi.Core/Providers/` for external integrations, `Guppi.Core/Configurations/` for settings
+6. **For the experimental shared graph:** Add an `IReplModule` under `Guppi.Repl/Skills`, mount it in `GuppiReplApp`, return typed records, annotate MCP behavior, and explicitly allow-list its paths before exposing them
+7. Optional: Add `Guppi.Core/Providers/` for external integrations, `Guppi.Core/Configurations/` for settings
 
 ## Gotchas
 
@@ -120,9 +134,11 @@ Per-skill configuration files are stored as JSON in:
 - System.CommandLine is a **pre-release beta** — avoid using APIs not already in the codebase
 - `Guppi.Core` exposes internals to `Guppi.Tests` via `InternalsVisibleTo`
 - CI runs on `ubuntu-latest` but the app targets Windows features (System.Speech, System.Management)
-- NuGet packages are published to **GitHub Packages** on merge to main — two packages: `dotnet-guppi` (CLI) and `dotnet-guppi-mcp` (MCP server)
+- CI publishes two packages on merge to main: `dotnet-guppi` and `dotnet-guppi-mcp`; `dotnet-guppi-repl` is experimental and intentionally not in publication workflows
 - The solution uses the new `.slnx` format (not `.sln`)
-- **MCP STDIO transport:** Never log to stdout in `Guppi.MCP` — it corrupts the JSON-RPC protocol. All logging must go to stderr (configured via `LogToStandardErrorThreshold`)
+- **MCP STDIO transport:** Never log to stdout in `Guppi.MCP` or `guppi.repl mcp serve` — it corrupts JSON-RPC; protocol smoke tests must parse every stdout line as JSON
+- Repl.Testing `0.11.0-dev.181` executes handlers with a session provider that does not include `app.Services`; inject pilot dependencies into `IReplModule` constructors, and use a real redirected interactive loop to test context navigation
+- `dotnet format Guppi.slnx --verify-no-changes` currently reports historical line-ending/import/encoding debt; verify the new projects individually and do not reformat unrelated files
 
 ## Workflow
 

--- a/Guppi.Core/Interfaces/Providers/IHueProvider.cs
+++ b/Guppi.Core/Interfaces/Providers/IHueProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Guppi.Core.Entities.Hue;
 
@@ -7,15 +8,15 @@ namespace Guppi.Core.Interfaces.Providers
 {
     public interface IHueProvider
     {
-        Task<IEnumerable<HueBridge>> ListBridges();
+        Task<IEnumerable<HueBridge>> ListBridges(CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<HueLight>> ListLights(string ip);
+        Task<IEnumerable<HueLight>> ListLights(string ip, CancellationToken cancellationToken = default);
 
-        Task Set(string ip, bool on, bool off, bool alert, byte? brightness, string color, uint light);
+        Task Set(string ip, bool on, bool off, bool alert, byte? brightness, string color, uint light, CancellationToken cancellationToken = default);
 
-        Task<bool> ConnectToBridge(string ip = null, bool loadKey = true);
+        Task<bool> ConnectToBridge(string ip = null, bool loadKey = true, CancellationToken cancellationToken = default);
 
-        Task<bool> Register(string ip = null);
+        Task<bool> Register(string ip = null, CancellationToken cancellationToken = default);
 
         Action<string> WaitForUserInput { get; set; }
     }

--- a/Guppi.Core/Interfaces/Services/IHueLightService.cs
+++ b/Guppi.Core/Interfaces/Services/IHueLightService.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using Guppi.Core.Services.Hue;
 using Guppi.Core.Entities.Hue;
+using Guppi.Core.Services.Hue;
 
 namespace Guppi.Core.Interfaces.Services;
 
 public interface IHueLightService
 {
     void Configure();
-    Task<bool> Register(string ipAddress, Action<string> waitForUserInput);
+    Task<bool> Register(string ipAddress, Action<string> waitForUserInput, CancellationToken cancellationToken = default);
     uint GetDefaultLight();
-    Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput);
-    Task<IEnumerable<HueBridge>> ListBridges();
-    Task SetLight(SetLightCommand request);
+    Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput, CancellationToken cancellationToken = default);
+    Task<IEnumerable<HueBridge>> ListBridges(CancellationToken cancellationToken = default);
+    Task SetLight(SetLightCommand request, CancellationToken cancellationToken = default);
 }

--- a/Guppi.Core/Providers/Hue/HueService.cs
+++ b/Guppi.Core/Providers/Hue/HueService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Guppi.Core;
 using Guppi.Core.Entities.Hue;
@@ -19,45 +20,57 @@ internal partial class HueProvider : IHueProvider
 {
     string _key;
     ILocalHueClient _client;
-    readonly RGBColor _black = new ("000000");
+    readonly RGBColor _black = new("000000");
 
     public Action<string> WaitForUserInput { get; set; } = null;
 
-    public async Task<IEnumerable<HueBridge>> ListBridges()
+    public async Task<IEnumerable<HueBridge>> ListBridges(CancellationToken cancellationToken = default)
     {
-        var locator = new HttpBridgeLocator();
-        IEnumerable<LocatedBridge> bridges = await locator.LocateBridgesAsync(TimeSpan.FromSeconds(5));
+        IEnumerable<LocatedBridge> bridges = await LocateBridges(cancellationToken);
         return bridges.Select(b => new HueBridge { BridgeId = b.BridgeId, IpAddress = b.IpAddress });
     }
 
-    public async Task<IEnumerable<HueLight>> ListLights(string ip)
+    public async Task<IEnumerable<HueLight>> ListLights(string ip, CancellationToken cancellationToken = default)
     {
-        if (await ConnectToBridge(ip) == false)
+        if (await ConnectToBridge(ip, cancellationToken: cancellationToken) == false)
             return Enumerable.Empty<HueLight>();
 
+        cancellationToken.ThrowIfCancellationRequested();
         var lights = await _client.GetLightsAsync();
+        cancellationToken.ThrowIfCancellationRequested();
         return lights.Select(l => new HueLight { Id = l.Id, Name = l.Name, On = l.State.On, Brightness = l.State.Brightness, Color = l.ToHex(), Type = l.Type });
     }
 
-    public async Task Set(string ip, bool on, bool off, bool alert, byte? brightness, string color, uint light)
+    public async Task Set(
+        string ip,
+        bool on,
+        bool off,
+        bool alert,
+        byte? brightness,
+        string color,
+        uint light,
+        CancellationToken cancellationToken = default)
     {
-        if (await ConnectToBridge(ip) == false)
+        if (await ConnectToBridge(ip, cancellationToken: cancellationToken) == false)
             return;
 
+        cancellationToken.ThrowIfCancellationRequested();
         var cmd = GetCommand(on, off, alert, brightness, color);
         var lts = GetLights(light);
         await SendCommand(cmd, lts);
     }
 
-    public async Task<bool> Register(string ip = null)
+    public async Task<bool> Register(string ip = null, CancellationToken cancellationToken = default)
     {
-        return await ConnectToBridge(ip, false);
+        return await ConnectToBridge(ip, false, cancellationToken);
     }
 
-    public async Task<bool> ConnectToBridge(string ip = null, bool loadKey = true)
+    public async Task<bool> ConnectToBridge(
+        string ip = null,
+        bool loadKey = true,
+        CancellationToken cancellationToken = default)
     {
-        var locator = new HttpBridgeLocator();
-        IEnumerable<LocatedBridge> bridges = await locator.LocateBridgesAsync(TimeSpan.FromSeconds(5));
+        IEnumerable<LocatedBridge> bridges = await LocateBridges(cancellationToken);
         LocatedBridge bridge = null;
         if (ip == null)
             bridge = bridges.FirstOrDefault();
@@ -76,7 +89,7 @@ internal partial class HueProvider : IHueProvider
 
         if (_key == null)
         {
-            _key = await Register(bridge);
+            _key = await Register(bridge, cancellationToken);
             if (_key == null)
                 return false;
 
@@ -88,20 +101,38 @@ internal partial class HueProvider : IHueProvider
         return true;
     }
 
-    async Task<string> Register(LocatedBridge bridge)
+    async Task<string> Register(LocatedBridge bridge, CancellationToken cancellationToken)
     {
         if (WaitForUserInput == null)
             throw new InvalidOperationException("You must set WaitForUserInput");
 
+        cancellationToken.ThrowIfCancellationRequested();
         WaitForUserInput("Press the button on your bridge then press ENTER");
+        cancellationToken.ThrowIfCancellationRequested();
         try
         {
             var client = new LocalHueClient(bridge.IpAddress);
             return await client.RegisterAsync("Alteridem.Hue.CLI", Environment.MachineName);
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             throw new InvalidOperationException(e.Message, e);
+        }
+    }
+
+    private static async Task<IEnumerable<LocatedBridge>> LocateBridges(
+        CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(5));
+        try
+        {
+            var locator = new HttpBridgeLocator();
+            return await locator.LocateBridgesAsync(timeout.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return [];
         }
     }
 

--- a/Guppi.Core/Services/HueLightService.cs
+++ b/Guppi.Core/Services/HueLightService.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Guppi.Core.Configurations;
-using Guppi.Core.Services.Hue;
 using Guppi.Core.Entities.Hue;
-using Guppi.Core.Interfaces.Services;
 using Guppi.Core.Interfaces.Providers;
+using Guppi.Core.Interfaces.Services;
+using Guppi.Core.Services.Hue;
 
 namespace Guppi.Core.Services;
 
@@ -27,24 +28,30 @@ internal sealed class HueLightService : IHueLightService
     public uint GetDefaultLight() =>
         Configuration.Load<HueConfiguration>("hue").GetDefaultLight();
 
-    public Task<IEnumerable<HueBridge>> ListBridges() =>
-        _hueService.ListBridges();
+    public Task<IEnumerable<HueBridge>> ListBridges(CancellationToken cancellationToken = default) =>
+        _hueService.ListBridges(cancellationToken);
 
-    public async Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput)
+    public async Task<IEnumerable<HueLight>> ListLights(
+        string ipAddress,
+        Action<string> waitForUserInput,
+        CancellationToken cancellationToken = default)
     {
         _hueService.WaitForUserInput = waitForUserInput;
-        return await _hueService.ListLights(ipAddress);
+        return await _hueService.ListLights(ipAddress, cancellationToken);
     }
 
-    public async Task<bool> Register(string ipAddress, Action<string> waitForUserInput)
+    public async Task<bool> Register(
+        string ipAddress,
+        Action<string> waitForUserInput,
+        CancellationToken cancellationToken = default)
     {
         _hueService.WaitForUserInput = waitForUserInput;
-        return await _hueService.Register(ipAddress);
+        return await _hueService.Register(ipAddress, cancellationToken);
     }
 
-    public async Task SetLight(SetLightCommand request)
+    public async Task SetLight(SetLightCommand request, CancellationToken cancellationToken = default)
     {
         _hueService.WaitForUserInput = request.WaitForUserInput;
-        await _hueService.Set(request.IpAddress, request.On, request.Off, request.Alert, request.Brightness, request.Color, request.Light);
+        await _hueService.Set(request.IpAddress, request.On, request.Off, request.Alert, request.Brightness, request.Color, request.Light, cancellationToken);
     }
 }

--- a/Guppi.Repl.Tests/GlobalUsings.cs
+++ b/Guppi.Repl.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using System;
+global using System.Threading.Tasks;
+global using FluentAssertions;
+global using Microsoft.Extensions.DependencyInjection;
+global using NUnit.Framework;
+global using Repl.Testing;

--- a/Guppi.Repl.Tests/Guppi.Repl.Tests.csproj
+++ b/Guppi.Repl.Tests/Guppi.Repl.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Repl.Testing" Version="0.11.0-dev.181" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Guppi.Repl\Guppi.Repl.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
+++ b/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using FluentAssertions;
+
+namespace Guppi.Repl.Tests.Mcp;
+
+[TestFixture]
+public sealed class McpModuleTests
+{
+    [Test]
+    [NonParallelizable]
+    public void McpServeCommandIsPresentOnCliGraph()
+    {
+        var originalOutput = Console.Out;
+        var originalError = Console.Error;
+        using var output = new StringWriter();
+
+        int exitCode;
+        try
+        {
+            Console.SetOut(output);
+            Console.SetError(output);
+            exitCode = GuppiReplApp.Create().Run(["mcp", "--help", "--no-logo"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+            Console.SetError(originalError);
+        }
+
+        exitCode.Should().Be(0, output.ToString());
+        output.ToString().Should().Contain("serve");
+    }
+}

--- a/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
+++ b/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
@@ -1,4 +1,10 @@
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 
 namespace Guppi.Repl.Tests.Mcp
@@ -7,6 +13,42 @@ namespace Guppi.Repl.Tests.Mcp
     [TestFixture]
     public sealed class McpModuleTests
     {
+        private static readonly string[] ApprovedCommandPaths =
+        [
+            "utilities date",
+            "utilities guid",
+            "ip local",
+            "hue bridges",
+            "hue lights",
+            "hue {light} on",
+            "hue {light} off",
+        ];
+
+        private static readonly string[] ApprovedToolNames =
+        [
+            "utilities_date",
+            "utilities_guid",
+            "ip_local",
+            "hue_bridges",
+            "hue_lights",
+            "hue_on",
+            "hue_off",
+        ];
+
+        [Test]
+        public void McpCommandFilterAllowsOnlyApprovedPaths()
+        {
+            var filter = typeof(GuppiReplApp).GetMethod(
+                "IsMcpCommandAllowed",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            filter.Should().NotBeNull("the MCP exposure policy must be independently testable");
+            ApprovedCommandPaths.Should().OnlyContain(path =>
+                (bool)filter.Invoke(null, new object[] { path }));
+            new[] { "hue register", "hue lights delete", "utilities secrets", "ip local admin" }
+                .Should().OnlyContain(path => !(bool)filter.Invoke(null, new object[] { path }));
+        }
+
         [Test]
         [NonParallelizable]
         public void McpServeCommandIsPresentOnCliGraph()
@@ -30,6 +72,165 @@ namespace Guppi.Repl.Tests.Mcp
 
             exitCode.Should().Be(0, output.ToString());
             output.ToString().Should().Contain("serve");
+        }
+
+        [Test]
+        public async Task McpStdioExposesExactTypedGraphAndExecutesAUtility()
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var server = StartMcpServer();
+            var stderrTask = server.StandardError.ReadToEndAsync(timeout.Token);
+
+            try
+            {
+                await SendAsync(server, new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new
+                    {
+                        protocolVersion = "2025-06-18",
+                        capabilities = new { },
+                        clientInfo = new { name = "guppi-tests", version = "1" },
+                    },
+                });
+                using var initialized = await ReadResponseAsync(server, 1, timeout.Token);
+                initialized.RootElement.GetProperty("result")
+                    .GetProperty("serverInfo").GetProperty("name").GetString()
+                    .Should().Be("Guppi");
+
+                await SendAsync(server, new
+                {
+                    jsonrpc = "2.0",
+                    method = "notifications/initialized",
+                    @params = new { },
+                });
+                await SendAsync(server, new
+                {
+                    jsonrpc = "2.0",
+                    id = 2,
+                    method = "tools/list",
+                    @params = new { },
+                });
+                using var listed = await ReadResponseAsync(server, 2, timeout.Token);
+                var tools = listed.RootElement.GetProperty("result").GetProperty("tools")
+                    .EnumerateArray().ToArray();
+                tools.Select(tool => tool.GetProperty("name").GetString())
+                    .Should().BeEquivalentTo(ApprovedToolNames);
+
+                var dateSchema = tools.Single(tool =>
+                    tool.GetProperty("name").GetString() == "utilities_date")
+                    .GetProperty("inputSchema");
+                dateSchema.GetProperty("properties").GetProperty("utc")
+                    .GetProperty("type").GetString().Should().Be("boolean");
+
+                var hueOnSchema = tools.Single(tool =>
+                    tool.GetProperty("name").GetString() == "hue_on")
+                    .GetProperty("inputSchema");
+                hueOnSchema.GetProperty("properties").GetProperty("brightness")
+                    .GetProperty("type").GetString().Should().Be("integer");
+                var hueOnAnnotations = tools.Single(tool =>
+                    tool.GetProperty("name").GetString() == "hue_on")
+                    .GetProperty("annotations");
+                hueOnAnnotations.GetProperty("destructiveHint").GetBoolean().Should().BeTrue();
+                hueOnAnnotations.GetProperty("idempotentHint").GetBoolean().Should().BeTrue();
+                hueOnAnnotations.GetProperty("openWorldHint").GetBoolean().Should().BeTrue();
+
+                await SendAsync(server, new
+                {
+                    jsonrpc = "2.0",
+                    id = 3,
+                    method = "tools/call",
+                    @params = new
+                    {
+                        name = "utilities_date",
+                        arguments = new { utc = true },
+                    },
+                });
+                using var called = await ReadResponseAsync(server, 3, timeout.Token);
+                var callResult = called.RootElement.GetProperty("result");
+                callResult.TryGetProperty("isError", out var isError).Should().BeTrue();
+                isError.GetBoolean().Should().BeFalse();
+            }
+            finally
+            {
+                server.StandardInput.Close();
+                try
+                {
+                    await server.WaitForExitAsync(timeout.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    server.Kill(true);
+                    await server.WaitForExitAsync();
+                    throw;
+                }
+            }
+
+            var stderr = await stderrTask;
+            server.ExitCode.Should().Be(0, stderr);
+        }
+
+        private static Process StartMcpServer()
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = Path.GetDirectoryName(typeof(GuppiReplApp).Assembly.Location),
+            };
+            startInfo.ArgumentList.Add(typeof(GuppiReplApp).Assembly.Location);
+            startInfo.ArgumentList.Add("mcp");
+            startInfo.ArgumentList.Add("serve");
+            startInfo.ArgumentList.Add("--no-logo");
+            return Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Could not start the Guppi MCP test process.");
+        }
+
+        private static async Task SendAsync(Process server, object request)
+        {
+            await server.StandardInput.WriteLineAsync(JsonSerializer.Serialize(request));
+            await server.StandardInput.FlushAsync();
+        }
+
+        private static async Task<JsonDocument> ReadResponseAsync(
+            Process server,
+            int requestId,
+            CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var line = await server.StandardOutput.ReadLineAsync(cancellationToken);
+                if (line is null)
+                {
+                    var stderr = await server.StandardError.ReadToEndAsync(cancellationToken);
+                    throw new AssertionException(
+                        $"MCP server exited before response {requestId}. stderr: {stderr}");
+                }
+
+                JsonDocument message;
+                try
+                {
+                    message = JsonDocument.Parse(line);
+                }
+                catch (JsonException exception)
+                {
+                    throw new AssertionException($"MCP stdout contained non-JSON data: {line}", exception);
+                }
+
+                if (message.RootElement.TryGetProperty("id", out var id)
+                    && id.ValueKind == JsonValueKind.Number
+                    && id.GetInt32() == requestId)
+                {
+                    return message;
+                }
+
+                message.Dispose();
+            }
         }
     }
 }

--- a/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
+++ b/Guppi.Repl.Tests/Mcp/McpModuleTests.cs
@@ -1,33 +1,35 @@
 using System.IO;
 using FluentAssertions;
 
-namespace Guppi.Repl.Tests.Mcp;
-
-[TestFixture]
-public sealed class McpModuleTests
+namespace Guppi.Repl.Tests.Mcp
 {
-    [Test]
-    [NonParallelizable]
-    public void McpServeCommandIsPresentOnCliGraph()
+
+    [TestFixture]
+    public sealed class McpModuleTests
     {
-        var originalOutput = Console.Out;
-        var originalError = Console.Error;
-        using var output = new StringWriter();
-
-        int exitCode;
-        try
+        [Test]
+        [NonParallelizable]
+        public void McpServeCommandIsPresentOnCliGraph()
         {
-            Console.SetOut(output);
-            Console.SetError(output);
-            exitCode = GuppiReplApp.Create().Run(["mcp", "--help", "--no-logo"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOutput);
-            Console.SetError(originalError);
-        }
+            var originalOutput = Console.Out;
+            var originalError = Console.Error;
+            using var output = new StringWriter();
 
-        exitCode.Should().Be(0, output.ToString());
-        output.ToString().Should().Contain("serve");
+            int exitCode;
+            try
+            {
+                Console.SetOut(output);
+                Console.SetError(output);
+                exitCode = GuppiReplApp.Create().Run(["mcp", "--help", "--no-logo"]);
+            }
+            finally
+            {
+                Console.SetOut(originalOutput);
+                Console.SetError(originalError);
+            }
+
+            exitCode.Should().Be(0, output.ToString());
+            output.ToString().Should().Contain("serve");
+        }
     }
 }

--- a/Guppi.Repl.Tests/Skills/HueModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/HueModuleTests.cs
@@ -5,41 +5,42 @@ using Guppi.Core.Interfaces.Services;
 using Guppi.Core.Services.Hue;
 using Guppi.Repl.Results;
 
-namespace Guppi.Repl.Tests.Skills;
-
-[TestFixture]
-public sealed class HueModuleTests
+namespace Guppi.Repl.Tests.Skills
 {
-    [Test]
-    public async Task BridgesReturnsTypedDiscoveryResults()
+
+    [TestFixture]
+    public sealed class HueModuleTests
     {
-        var fake = new FakeHueLightService
+        [Test]
+        public async Task BridgesReturnsTypedDiscoveryResults()
         {
-            Bridges =
-            [
-                new HueBridge { BridgeId = "bridge-1", IpAddress = "192.0.2.10" },
+            var fake = new FakeHueLightService
+            {
+                Bridges =
+                [
+                    new HueBridge { BridgeId = "bridge-1", IpAddress = "192.0.2.10" },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("hue bridges --json --no-logo");
+            var execution = await session.RunCommandAsync("hue bridges --json --no-logo");
 
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.GetResult<HueBridgeResult[]>().Should().Equal(
-            new HueBridgeResult("bridge-1", "192.0.2.10"));
-        fake.ListBridgesCallCount.Should().Be(1);
-    }
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.GetResult<HueBridgeResult[]>().Should().Equal(
+                new HueBridgeResult("bridge-1", "192.0.2.10"));
+            fake.ListBridgesCallCount.Should().Be(1);
+        }
 
-    [Test]
-    public async Task LightsReturnsTypedResultsForSelectedBridge()
-    {
-        var fake = new FakeHueLightService
+        [Test]
+        public async Task LightsReturnsTypedResultsForSelectedBridge()
         {
-            Lights =
-            [
-                new HueLight
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight
                 {
                     Id = "7",
                     Name = "Kitchen",
@@ -49,208 +50,209 @@ public sealed class HueModuleTests
                     Type = "Extended color light",
                 },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("hue lights --ip 192.0.2.10 --json --no-logo");
+            var execution = await session.RunCommandAsync("hue lights --ip 192.0.2.10 --json --no-logo");
 
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.GetResult<HueLightResult[]>().Should().Equal(
-            new HueLightResult("7", "Kitchen", true, 200, "#ffaa00", "Extended color light"));
-        fake.ListLightsCallCount.Should().Be(1);
-        fake.LastIpAddress.Should().Be("192.0.2.10");
-    }
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.GetResult<HueLightResult[]>().Should().Equal(
+                new HueLightResult("7", "Kitchen", true, 200, "#ffaa00", "Extended color light"));
+            fake.ListLightsCallCount.Should().Be(1);
+            fake.LastIpAddress.Should().Be("192.0.2.10");
+        }
 
-    [Test]
-    public async Task OnResolvesLightNameAndSendsTypedCommand()
-    {
-        var fake = new FakeHueLightService
+        [Test]
+        public async Task OnResolvesLightNameAndSendsTypedCommand()
         {
-            Lights =
-            [
-                new HueLight { Id = "7", Name = "Kitchen" },
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync(
-            "hue kItChEn on --ip 192.0.2.10 --brightness 128 --color red --json --no-logo");
+            var execution = await session.RunCommandAsync(
+                "hue kItChEn on --ip 192.0.2.10 --brightness 128 --color red --json --no-logo");
 
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.GetResult<HueActionResult>().Should().Be(
-            new HueActionResult("7", "Kitchen", true, 128, "red", "192.0.2.10"));
-        fake.SetLightCallCount.Should().Be(1);
-        fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.GetResult<HueActionResult>().Should().Be(
+                new HueActionResult("7", "Kitchen", true, 128, "red", "192.0.2.10"));
+            fake.SetLightCallCount.Should().Be(1);
+            fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+            {
+                IpAddress = "192.0.2.10",
+                Light = 7,
+                On = true,
+                Off = false,
+                Brightness = 128,
+                Color = "red",
+            }, options => options.Excluding(command => command.WaitForUserInput));
+        }
+
+        [Test]
+        public async Task OffResolvesNumericIdAndSendsTypedCommand()
         {
-            IpAddress = "192.0.2.10",
-            Light = 7,
-            On = true,
-            Off = false,
-            Brightness = 128,
-            Color = "red",
-        }, options => options.Excluding(command => command.WaitForUserInput));
-    }
-
-    [Test]
-    public async Task OffResolvesNumericIdAndSendsTypedCommand()
-    {
-        var fake = new FakeHueLightService
-        {
-            Lights =
-            [
-                new HueLight { Id = "7", Name = "Kitchen" },
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync(
-            "hue 7 off --ip 192.0.2.10 --json --no-logo");
+            var execution = await session.RunCommandAsync(
+                "hue 7 off --ip 192.0.2.10 --json --no-logo");
 
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.GetResult<HueActionResult>().Should().Be(
-            new HueActionResult("7", "Kitchen", false, null, null, "192.0.2.10"));
-        fake.SetLightCallCount.Should().Be(1);
-        fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.GetResult<HueActionResult>().Should().Be(
+                new HueActionResult("7", "Kitchen", false, null, null, "192.0.2.10"));
+            fake.SetLightCallCount.Should().Be(1);
+            fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+            {
+                IpAddress = "192.0.2.10",
+                Light = 7,
+                On = false,
+                Off = true,
+            }, options => options.Excluding(command => command.WaitForUserInput));
+        }
+
+        [Test]
+        public async Task UnknownLightReturnsValidationWithoutMutation()
         {
-            IpAddress = "192.0.2.10",
-            Light = 7,
-            On = false,
-            Off = true,
-        }, options => options.Excluding(command => command.WaitForUserInput));
-    }
-
-    [Test]
-    public async Task UnknownLightReturnsValidationWithoutMutation()
-    {
-        var fake = new FakeHueLightService
-        {
-            Lights =
-            [
-                new HueLight { Id = "7", Name = "Kitchen" },
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("hue unknown on --json --no-logo");
+            var execution = await session.RunCommandAsync("hue unknown on --json --no-logo");
 
-        execution.ExitCode.Should().Be(1);
-        execution.OutputText.Should().Contain("\"kind\": \"validation\"");
-        execution.OutputText.Should().Contain("Hue light unknown was not found.");
-        fake.SetLightCallCount.Should().Be(0);
-    }
+            execution.ExitCode.Should().Be(1);
+            execution.OutputText.Should().Contain("\"kind\": \"validation\"");
+            execution.OutputText.Should().Contain("Hue light unknown was not found.");
+            fake.SetLightCallCount.Should().Be(0);
+        }
 
-    [Test]
-    public async Task LightCompletionReturnsMatchingNamesAndIds()
-    {
-        var fake = new FakeHueLightService
+        [Test]
+        public async Task LightCompletionReturnsMatchingNamesAndIds()
         {
-            Lights =
-            [
-                new HueLight { Id = "7", Name = "Kitchen" },
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
                 new HueLight { Id = "8", Name = "Bedroom" },
             ],
-        };
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
-        await using var session = await host.OpenSessionAsync();
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync(
-            "complete hue placeholder on --target light --input Kit --no-logo");
+            var execution = await session.RunCommandAsync(
+                "complete hue placeholder on --target light --input Kit --no-logo");
 
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.OutputText.Should().Contain("Kitchen");
-        execution.OutputText.Should().NotContain("Bedroom");
-        fake.ListLightsCallCount.Should().Be(1);
-    }
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.OutputText.Should().Contain("Kitchen");
+            execution.OutputText.Should().NotContain("Bedroom");
+            fake.ListLightsCallCount.Should().Be(1);
+        }
 
-    [Test]
-    [NonParallelizable]
-    public void InteractiveLoopNavigatesHueAndBackToUtilities()
-    {
-        var fake = new FakeHueLightService
+        [Test]
+        [NonParallelizable]
+        public void InteractiveLoopNavigatesHueAndBackToUtilities()
         {
-            Lights =
-            [
-                new HueLight { Id = "7", Name = "Kitchen" },
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
             ],
-        };
-        var originalInput = Console.In;
-        var originalOutput = Console.Out;
-        var originalError = Console.Error;
-        using var input = new StringReader("lights --json\nKitchen on --json\n..\nutilities date --json\nexit\n");
-        using var output = new StringWriter();
+            };
+            var originalInput = Console.In;
+            var originalOutput = Console.Out;
+            var originalError = Console.Error;
+            using var input = new StringReader("lights --json\nKitchen on --json\n..\nutilities date --json\nexit\n");
+            using var output = new StringWriter();
 
-        int exitCode;
-        try
-        {
-            Console.SetIn(input);
-            Console.SetOut(output);
-            Console.SetError(output);
-            var app = GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake));
-            exitCode = app.Run(["hue", "--no-logo"]);
-        }
-        finally
-        {
-            Console.SetIn(originalInput);
-            Console.SetOut(originalOutput);
-            Console.SetError(originalError);
-        }
+            int exitCode;
+            try
+            {
+                Console.SetIn(input);
+                Console.SetOut(output);
+                Console.SetError(output);
+                var app = GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake));
+                exitCode = app.Run(["hue", "--no-logo"]);
+            }
+            finally
+            {
+                Console.SetIn(originalInput);
+                Console.SetOut(originalOutput);
+                Console.SetError(originalError);
+            }
 
-        exitCode.Should().Be(0, output.ToString());
-        output.ToString().Should().Contain("Kitchen");
-        output.ToString().Should().Contain("value");
-        fake.SetLightCallCount.Should().Be(1);
-    }
-
-    private sealed class FakeHueLightService : IHueLightService
-    {
-        public HueBridge[] Bridges { get; init; } = [];
-
-        public HueLight[] Lights { get; init; } = [];
-
-        public int ListLightsCallCount { get; private set; }
-
-        public string LastIpAddress { get; private set; }
-
-        public SetLightCommand LastSetLight { get; private set; }
-
-        public int SetLightCallCount { get; private set; }
-
-        public int ListBridgesCallCount { get; private set; }
-
-        public void Configure() => throw new NotSupportedException();
-
-        public Task<bool> Register(string ipAddress, Action<string> waitForUserInput) =>
-            throw new NotSupportedException();
-
-        public uint GetDefaultLight() => throw new NotSupportedException();
-
-        public Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput)
-        {
-            ListLightsCallCount++;
-            LastIpAddress = ipAddress;
-            return Task.FromResult<IEnumerable<HueLight>>(Lights);
+            exitCode.Should().Be(0, output.ToString());
+            output.ToString().Should().Contain("Kitchen");
+            output.ToString().Should().Contain("value");
+            fake.SetLightCallCount.Should().Be(1);
         }
 
-        public Task<IEnumerable<HueBridge>> ListBridges()
+        private sealed class FakeHueLightService : IHueLightService
         {
-            ListBridgesCallCount++;
-            return Task.FromResult<IEnumerable<HueBridge>>(Bridges);
-        }
+            public HueBridge[] Bridges { get; init; } = [];
 
-        public Task SetLight(SetLightCommand request)
-        {
-            SetLightCallCount++;
-            LastSetLight = request;
-            return Task.CompletedTask;
+            public HueLight[] Lights { get; init; } = [];
+
+            public int ListLightsCallCount { get; private set; }
+
+            public string LastIpAddress { get; private set; }
+
+            public SetLightCommand LastSetLight { get; private set; }
+
+            public int SetLightCallCount { get; private set; }
+
+            public int ListBridgesCallCount { get; private set; }
+
+            public void Configure() => throw new NotSupportedException();
+
+            public Task<bool> Register(string ipAddress, Action<string> waitForUserInput) =>
+                throw new NotSupportedException();
+
+            public uint GetDefaultLight() => throw new NotSupportedException();
+
+            public Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput)
+            {
+                ListLightsCallCount++;
+                LastIpAddress = ipAddress;
+                return Task.FromResult<IEnumerable<HueLight>>(Lights);
+            }
+
+            public Task<IEnumerable<HueBridge>> ListBridges()
+            {
+                ListBridgesCallCount++;
+                return Task.FromResult<IEnumerable<HueBridge>>(Bridges);
+            }
+
+            public Task SetLight(SetLightCommand request)
+            {
+                SetLightCallCount++;
+                LastSetLight = request;
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/Guppi.Repl.Tests/Skills/HueModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/HueModuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Guppi.Core.Entities.Hue;
 using Guppi.Core.Interfaces.Services;
 using Guppi.Core.Services.Hue;
@@ -79,11 +80,11 @@ namespace Guppi.Repl.Tests.Skills
             await using var session = await host.OpenSessionAsync();
 
             var execution = await session.RunCommandAsync(
-                "hue kItChEn on --ip 192.0.2.10 --brightness 128 --color red --json --no-logo");
+                "hue kItChEn on --ip 192.0.2.10 --brightness 80 --color red --json --no-logo");
 
             execution.ExitCode.Should().Be(0, execution.OutputText);
             execution.GetResult<HueActionResult>().Should().Be(
-                new HueActionResult("7", "Kitchen", true, 128, "red", "192.0.2.10"));
+                new HueActionResult("7", "Kitchen", true, 80, "red", "192.0.2.10"));
             fake.SetLightCallCount.Should().Be(1);
             fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
             {
@@ -91,7 +92,7 @@ namespace Guppi.Repl.Tests.Skills
                 Light = 7,
                 On = true,
                 Off = false,
-                Brightness = 128,
+                Brightness = 80,
                 Color = "red",
             }, options => options.Excluding(command => command.WaitForUserInput));
         }
@@ -124,6 +125,69 @@ namespace Guppi.Repl.Tests.Skills
                 On = false,
                 Off = true,
             }, options => options.Excluding(command => command.WaitForUserInput));
+        }
+
+        [Test]
+        public async Task BrightnessOutsidePercentageRangeReturnsValidationWithoutMutation()
+        {
+            var fake = new FakeHueLightService
+            {
+                Lights = [new HueLight { Id = "7", Name = "Kitchen" }],
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
+
+            var execution = await session.RunCommandAsync(
+                "hue Kitchen on --brightness 101 --json --no-logo");
+
+            execution.ExitCode.Should().Be(1);
+            execution.OutputText.Should().Contain("Brightness must be between 0 and 100 percent.");
+            fake.SetLightCallCount.Should().Be(0);
+        }
+
+        [Test]
+        public async Task NumericInputPrioritizesAnExactIdOverTheSameName()
+        {
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "8", Name = "7" },
+                    new HueLight { Id = "7", Name = "Kitchen" },
+                ],
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
+
+            var execution = await session.RunCommandAsync("hue 7 off --json --no-logo");
+
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            fake.LastSetLight.Light.Should().Be(7);
+            execution.GetResult<HueActionResult>().LightName.Should().Be("Kitchen");
+        }
+
+        [Test]
+        public async Task DuplicateLightNameReturnsValidationWithCandidateIdsWithoutMutation()
+        {
+            var fake = new FakeHueLightService
+            {
+                Lights =
+                [
+                    new HueLight { Id = "7", Name = "Kitchen" },
+                    new HueLight { Id = "8", Name = "kitchen" },
+                ],
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
+
+            var execution = await session.RunCommandAsync("hue Kitchen off --json --no-logo");
+
+            execution.ExitCode.Should().Be(1);
+            execution.OutputText.Should().Contain("Hue light name Kitchen is ambiguous. Use one of these IDs: 7, 8.");
+            fake.SetLightCallCount.Should().Be(0);
         }
 
         [Test]
@@ -173,6 +237,51 @@ namespace Guppi.Repl.Tests.Skills
         }
 
         [Test]
+        public async Task HueInvocationPassesCancellationTokenToDiscoveryAndMutation()
+        {
+            var fake = new FakeHueLightService
+            {
+                Lights = [new HueLight { Id = "7", Name = "Kitchen" }],
+            };
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+            await using var session = await host.OpenSessionAsync();
+            using var cancellation = new CancellationTokenSource();
+
+            var execution = await session.RunCommandAsync(
+                "hue Kitchen on --json --no-logo",
+                cancellation.Token);
+
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            fake.ListLightsCancellationToken.Should().NotBeNull();
+            fake.ListLightsCancellationToken.Value.CanBeCanceled.Should().BeTrue();
+            fake.SetLightCancellationToken.Should().Be(fake.ListLightsCancellationToken);
+        }
+
+        [Test]
+        public async Task HueServiceIsResolvedPerCommandInvocation()
+        {
+            var createdServices = 0;
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services => services.AddTransient<IHueLightService>(_ =>
+                {
+                    createdServices++;
+                    return new FakeHueLightService
+                    {
+                        Lights = [new HueLight { Id = "7", Name = "Kitchen" }],
+                    };
+                })));
+            await using var session = await host.OpenSessionAsync();
+
+            var first = await session.RunCommandAsync("hue lights --json --no-logo");
+            var second = await session.RunCommandAsync("hue lights --json --no-logo");
+
+            first.ExitCode.Should().Be(0, first.OutputText);
+            second.ExitCode.Should().Be(0, second.OutputText);
+            createdServices.Should().Be(2);
+        }
+
+        [Test]
         [NonParallelizable]
         public void InteractiveLoopNavigatesHueAndBackToUtilities()
         {
@@ -219,6 +328,10 @@ namespace Guppi.Repl.Tests.Skills
 
             public int ListLightsCallCount { get; private set; }
 
+            public CancellationToken? ListLightsCancellationToken { get; private set; }
+
+            public CancellationToken? SetLightCancellationToken { get; private set; }
+
             public string LastIpAddress { get; private set; }
 
             public SetLightCommand LastSetLight { get; private set; }
@@ -229,25 +342,43 @@ namespace Guppi.Repl.Tests.Skills
 
             public void Configure() => throw new NotSupportedException();
 
-            public Task<bool> Register(string ipAddress, Action<string> waitForUserInput) =>
+            public Task<bool> Register(
+                string ipAddress,
+                Action<string> waitForUserInput,
+                CancellationToken cancellationToken = default) =>
                 throw new NotSupportedException();
 
             public uint GetDefaultLight() => throw new NotSupportedException();
 
-            public Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput)
+            public Task<IEnumerable<HueLight>> ListLights(
+                string ipAddress,
+                Action<string> waitForUserInput,
+                CancellationToken cancellationToken)
+            {
+                ListLightsCancellationToken = cancellationToken;
+                return ListLightsCore(ipAddress);
+            }
+
+            private Task<IEnumerable<HueLight>> ListLightsCore(string ipAddress)
             {
                 ListLightsCallCount++;
                 LastIpAddress = ipAddress;
                 return Task.FromResult<IEnumerable<HueLight>>(Lights);
             }
 
-            public Task<IEnumerable<HueBridge>> ListBridges()
+            public Task<IEnumerable<HueBridge>> ListBridges(CancellationToken cancellationToken = default)
             {
                 ListBridgesCallCount++;
                 return Task.FromResult<IEnumerable<HueBridge>>(Bridges);
             }
 
-            public Task SetLight(SetLightCommand request)
+            public Task SetLight(SetLightCommand request, CancellationToken cancellationToken)
+            {
+                SetLightCancellationToken = cancellationToken;
+                return SetLightCore(request);
+            }
+
+            private Task SetLightCore(SetLightCommand request)
             {
                 SetLightCallCount++;
                 LastSetLight = request;

--- a/Guppi.Repl.Tests/Skills/HueModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/HueModuleTests.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+using System.IO;
+using Guppi.Core.Entities.Hue;
+using Guppi.Core.Interfaces.Services;
+using Guppi.Core.Services.Hue;
+using Guppi.Repl.Results;
+
+namespace Guppi.Repl.Tests.Skills;
+
+[TestFixture]
+public sealed class HueModuleTests
+{
+    [Test]
+    public async Task BridgesReturnsTypedDiscoveryResults()
+    {
+        var fake = new FakeHueLightService
+        {
+            Bridges =
+            [
+                new HueBridge { BridgeId = "bridge-1", IpAddress = "192.0.2.10" },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("hue bridges --json --no-logo");
+
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.GetResult<HueBridgeResult[]>().Should().Equal(
+            new HueBridgeResult("bridge-1", "192.0.2.10"));
+        fake.ListBridgesCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task LightsReturnsTypedResultsForSelectedBridge()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight
+                {
+                    Id = "7",
+                    Name = "Kitchen",
+                    On = true,
+                    Brightness = 200,
+                    Color = "#ffaa00",
+                    Type = "Extended color light",
+                },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("hue lights --ip 192.0.2.10 --json --no-logo");
+
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.GetResult<HueLightResult[]>().Should().Equal(
+            new HueLightResult("7", "Kitchen", true, 200, "#ffaa00", "Extended color light"));
+        fake.ListLightsCallCount.Should().Be(1);
+        fake.LastIpAddress.Should().Be("192.0.2.10");
+    }
+
+    [Test]
+    public async Task OnResolvesLightNameAndSendsTypedCommand()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight { Id = "7", Name = "Kitchen" },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync(
+            "hue kItChEn on --ip 192.0.2.10 --brightness 128 --color red --json --no-logo");
+
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.GetResult<HueActionResult>().Should().Be(
+            new HueActionResult("7", "Kitchen", true, 128, "red", "192.0.2.10"));
+        fake.SetLightCallCount.Should().Be(1);
+        fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+        {
+            IpAddress = "192.0.2.10",
+            Light = 7,
+            On = true,
+            Off = false,
+            Brightness = 128,
+            Color = "red",
+        }, options => options.Excluding(command => command.WaitForUserInput));
+    }
+
+    [Test]
+    public async Task OffResolvesNumericIdAndSendsTypedCommand()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight { Id = "7", Name = "Kitchen" },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync(
+            "hue 7 off --ip 192.0.2.10 --json --no-logo");
+
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.GetResult<HueActionResult>().Should().Be(
+            new HueActionResult("7", "Kitchen", false, null, null, "192.0.2.10"));
+        fake.SetLightCallCount.Should().Be(1);
+        fake.LastSetLight.Should().BeEquivalentTo(new SetLightCommand
+        {
+            IpAddress = "192.0.2.10",
+            Light = 7,
+            On = false,
+            Off = true,
+        }, options => options.Excluding(command => command.WaitForUserInput));
+    }
+
+    [Test]
+    public async Task UnknownLightReturnsValidationWithoutMutation()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight { Id = "7", Name = "Kitchen" },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("hue unknown on --json --no-logo");
+
+        execution.ExitCode.Should().Be(1);
+        execution.OutputText.Should().Contain("\"kind\": \"validation\"");
+        execution.OutputText.Should().Contain("Hue light unknown was not found.");
+        fake.SetLightCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task LightCompletionReturnsMatchingNamesAndIds()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight { Id = "7", Name = "Kitchen" },
+                new HueLight { Id = "8", Name = "Bedroom" },
+            ],
+        };
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake)));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync(
+            "complete hue placeholder on --target light --input Kit --no-logo");
+
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.OutputText.Should().Contain("Kitchen");
+        execution.OutputText.Should().NotContain("Bedroom");
+        fake.ListLightsCallCount.Should().Be(1);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void InteractiveLoopNavigatesHueAndBackToUtilities()
+    {
+        var fake = new FakeHueLightService
+        {
+            Lights =
+            [
+                new HueLight { Id = "7", Name = "Kitchen" },
+            ],
+        };
+        var originalInput = Console.In;
+        var originalOutput = Console.Out;
+        var originalError = Console.Error;
+        using var input = new StringReader("lights --json\nKitchen on --json\n..\nutilities date --json\nexit\n");
+        using var output = new StringWriter();
+
+        int exitCode;
+        try
+        {
+            Console.SetIn(input);
+            Console.SetOut(output);
+            Console.SetError(output);
+            var app = GuppiReplApp.Create(services => services.AddSingleton<IHueLightService>(fake));
+            exitCode = app.Run(["hue", "--no-logo"]);
+        }
+        finally
+        {
+            Console.SetIn(originalInput);
+            Console.SetOut(originalOutput);
+            Console.SetError(originalError);
+        }
+
+        exitCode.Should().Be(0, output.ToString());
+        output.ToString().Should().Contain("Kitchen");
+        output.ToString().Should().Contain("value");
+        fake.SetLightCallCount.Should().Be(1);
+    }
+
+    private sealed class FakeHueLightService : IHueLightService
+    {
+        public HueBridge[] Bridges { get; init; } = [];
+
+        public HueLight[] Lights { get; init; } = [];
+
+        public int ListLightsCallCount { get; private set; }
+
+        public string LastIpAddress { get; private set; }
+
+        public SetLightCommand LastSetLight { get; private set; }
+
+        public int SetLightCallCount { get; private set; }
+
+        public int ListBridgesCallCount { get; private set; }
+
+        public void Configure() => throw new NotSupportedException();
+
+        public Task<bool> Register(string ipAddress, Action<string> waitForUserInput) =>
+            throw new NotSupportedException();
+
+        public uint GetDefaultLight() => throw new NotSupportedException();
+
+        public Task<IEnumerable<HueLight>> ListLights(string ipAddress, Action<string> waitForUserInput)
+        {
+            ListLightsCallCount++;
+            LastIpAddress = ipAddress;
+            return Task.FromResult<IEnumerable<HueLight>>(Lights);
+        }
+
+        public Task<IEnumerable<HueBridge>> ListBridges()
+        {
+            ListBridgesCallCount++;
+            return Task.FromResult<IEnumerable<HueBridge>>(Bridges);
+        }
+
+        public Task SetLight(SetLightCommand request)
+        {
+            SetLightCallCount++;
+            LastSetLight = request;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Guppi.Repl.Tests/Skills/IpModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/IpModuleTests.cs
@@ -1,40 +1,42 @@
 using Guppi.Repl.Results;
 using Guppi.Repl.Skills;
 
-namespace Guppi.Repl.Tests.Skills;
-
-[TestFixture]
-public sealed class IpModuleTests
+namespace Guppi.Repl.Tests.Skills
 {
-    [Test]
-    public async Task LocalReturnsTypedIpv4Addresses()
+
+    [TestFixture]
+    public sealed class IpModuleTests
     {
-        var addresses = new[]
+        [Test]
+        public async Task LocalReturnsTypedIpv4Addresses()
         {
+            var addresses = new[]
+            {
             new LocalIpAddressResult("Ethernet", "192.0.2.42"),
         };
-        var fake = new FakeLocalIpAddressProvider(addresses);
-        var app = GuppiReplApp.Create(services =>
-            services.AddSingleton<ILocalIpAddressProvider>(fake));
-        app.Services.GetRequiredService<ILocalIpAddressProvider>().Should().BeSameAs(fake);
-        await using var host = ReplTestHost.Create(() => app);
-        await using var session = await host.OpenSessionAsync();
+            var fake = new FakeLocalIpAddressProvider(addresses);
+            var app = GuppiReplApp.Create(services =>
+                services.AddSingleton<ILocalIpAddressProvider>(fake));
+            app.Services.GetRequiredService<ILocalIpAddressProvider>().Should().BeSameAs(fake);
+            await using var host = ReplTestHost.Create(() => app);
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("ip local --json --no-logo");
+            var execution = await session.RunCommandAsync("ip local --json --no-logo");
 
-        fake.CallCount.Should().Be(1);
-        execution.ExitCode.Should().Be(0, execution.OutputText);
-        execution.GetResult<LocalIpAddressResult[]>().Should().Equal(addresses);
-    }
+            fake.CallCount.Should().Be(1);
+            execution.ExitCode.Should().Be(0, execution.OutputText);
+            execution.GetResult<LocalIpAddressResult[]>().Should().Equal(addresses);
+        }
 
-    private sealed class FakeLocalIpAddressProvider(LocalIpAddressResult[] addresses) : ILocalIpAddressProvider
-    {
-        public int CallCount { get; private set; }
-
-        public LocalIpAddressResult[] GetLocalAddresses()
+        private sealed class FakeLocalIpAddressProvider(LocalIpAddressResult[] addresses) : ILocalIpAddressProvider
         {
-            CallCount++;
-            return addresses;
+            public int CallCount { get; private set; }
+
+            public LocalIpAddressResult[] GetLocalAddresses()
+            {
+                CallCount++;
+                return addresses;
+            }
         }
     }
 }

--- a/Guppi.Repl.Tests/Skills/IpModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/IpModuleTests.cs
@@ -1,0 +1,40 @@
+using Guppi.Repl.Results;
+using Guppi.Repl.Skills;
+
+namespace Guppi.Repl.Tests.Skills;
+
+[TestFixture]
+public sealed class IpModuleTests
+{
+    [Test]
+    public async Task LocalReturnsTypedIpv4Addresses()
+    {
+        var addresses = new[]
+        {
+            new LocalIpAddressResult("Ethernet", "192.0.2.42"),
+        };
+        var fake = new FakeLocalIpAddressProvider(addresses);
+        var app = GuppiReplApp.Create(services =>
+            services.AddSingleton<ILocalIpAddressProvider>(fake));
+        app.Services.GetRequiredService<ILocalIpAddressProvider>().Should().BeSameAs(fake);
+        await using var host = ReplTestHost.Create(() => app);
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("ip local --json --no-logo");
+
+        fake.CallCount.Should().Be(1);
+        execution.ExitCode.Should().Be(0, execution.OutputText);
+        execution.GetResult<LocalIpAddressResult[]>().Should().Equal(addresses);
+    }
+
+    private sealed class FakeLocalIpAddressProvider(LocalIpAddressResult[] addresses) : ILocalIpAddressProvider
+    {
+        public int CallCount { get; private set; }
+
+        public LocalIpAddressResult[] GetLocalAddresses()
+        {
+            CallCount++;
+            return addresses;
+        }
+    }
+}

--- a/Guppi.Repl.Tests/Skills/UtilitiesModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/UtilitiesModuleTests.cs
@@ -1,43 +1,45 @@
 using Guppi.Repl.Results;
 
-namespace Guppi.Repl.Tests.Skills;
-
-[TestFixture]
-public sealed class UtilitiesModuleTests
+namespace Guppi.Repl.Tests.Skills
 {
-    [Test]
-    public async Task DateReturnsTypedUtcResult()
+
+    [TestFixture]
+    public sealed class UtilitiesModuleTests
     {
-        var fixedTime = new DateTimeOffset(2030, 1, 2, 12, 34, 56, TimeSpan.Zero);
-        await using var host = ReplTestHost.Create(() =>
-            GuppiReplApp.Create(services =>
-                services.AddSingleton<TimeProvider>(new FixedTimeProvider(fixedTime))));
-        await using var session = await host.OpenSessionAsync();
+        [Test]
+        public async Task DateReturnsTypedUtcResult()
+        {
+            var fixedTime = new DateTimeOffset(2030, 1, 2, 12, 34, 56, TimeSpan.Zero);
+            await using var host = ReplTestHost.Create(() =>
+                GuppiReplApp.Create(services =>
+                    services.AddSingleton<TimeProvider>(new FixedTimeProvider(fixedTime))));
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("utilities date --utc --json --no-logo");
+            var execution = await session.RunCommandAsync("utilities date --utc --json --no-logo");
 
-        execution.ExitCode.Should().Be(0);
-        var result = execution.GetResult<DateResult>();
-        result.Value.Should().Be(new DateOnly(2030, 1, 2));
-        result.IsUtc.Should().BeTrue();
-    }
+            execution.ExitCode.Should().Be(0);
+            var result = execution.GetResult<DateResult>();
+            result.Value.Should().Be(new DateOnly(2030, 1, 2));
+            result.IsUtc.Should().BeTrue();
+        }
 
-    [Test]
-    public async Task GuidReturnsTypedNonEmptyResult()
-    {
-        await using var host = ReplTestHost.Create(() => GuppiReplApp.Create());
-        await using var session = await host.OpenSessionAsync();
+        [Test]
+        public async Task GuidReturnsTypedNonEmptyResult()
+        {
+            await using var host = ReplTestHost.Create(() => GuppiReplApp.Create());
+            await using var session = await host.OpenSessionAsync();
 
-        var execution = await session.RunCommandAsync("utilities guid --json --no-logo");
+            var execution = await session.RunCommandAsync("utilities guid --json --no-logo");
 
-        execution.ExitCode.Should().Be(0);
-        execution.GetResult<GuidResult>().Value.Should().NotBe(Guid.Empty);
-    }
+            execution.ExitCode.Should().Be(0);
+            execution.GetResult<GuidResult>().Value.Should().NotBe(Guid.Empty);
+        }
 
-    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => utcNow;
+        private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => utcNow;
 
-        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+            public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+        }
     }
 }

--- a/Guppi.Repl.Tests/Skills/UtilitiesModuleTests.cs
+++ b/Guppi.Repl.Tests/Skills/UtilitiesModuleTests.cs
@@ -1,0 +1,43 @@
+using Guppi.Repl.Results;
+
+namespace Guppi.Repl.Tests.Skills;
+
+[TestFixture]
+public sealed class UtilitiesModuleTests
+{
+    [Test]
+    public async Task DateReturnsTypedUtcResult()
+    {
+        var fixedTime = new DateTimeOffset(2030, 1, 2, 12, 34, 56, TimeSpan.Zero);
+        await using var host = ReplTestHost.Create(() =>
+            GuppiReplApp.Create(services =>
+                services.AddSingleton<TimeProvider>(new FixedTimeProvider(fixedTime))));
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("utilities date --utc --json --no-logo");
+
+        execution.ExitCode.Should().Be(0);
+        var result = execution.GetResult<DateResult>();
+        result.Value.Should().Be(new DateOnly(2030, 1, 2));
+        result.IsUtc.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GuidReturnsTypedNonEmptyResult()
+    {
+        await using var host = ReplTestHost.Create(() => GuppiReplApp.Create());
+        await using var session = await host.OpenSessionAsync();
+
+        var execution = await session.RunCommandAsync("utilities guid --json --no-logo");
+
+        execution.ExitCode.Should().Be(0);
+        execution.GetResult<GuidResult>().Value.Should().NotBe(Guid.Empty);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+
+        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+    }
+}

--- a/Guppi.Repl/Guppi.Repl.csproj
+++ b/Guppi.Repl/Guppi.Repl.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Guppi.Repl</RootNamespace>
+    <AssemblyName>guppi.repl</AssemblyName>
+    <Product>Guppi Repl pilot</Product>
+    <Description>Experimental Guppi pilot using one Repl command graph for CLI, interactive REPL, and MCP.</Description>
+    <PackageId>dotnet-guppi-repl</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>guppi.repl</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/rprouse/guppi</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>ackbar.png</PackageIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="nupkg\**" />
+    <EmbeddedResource Remove="nupkg\**" />
+    <None Remove="nupkg\**" />
+    <None Include="..\img\ackbar.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Repl" Version="0.11.0-dev.181" />
+    <PackageReference Include="Repl.Mcp" Version="0.11.0-dev.181" />
+    <PackageReference Include="Repl.Spectre" Version="0.11.0-dev.181" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Guppi.Core\Guppi.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Guppi.Repl/Guppi.Repl.csproj
+++ b/Guppi.Repl/Guppi.Repl.csproj
@@ -16,6 +16,9 @@
     <RepositoryUrl>https://github.com/rprouse/guppi</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>ackbar.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- Playwright runtime PowerShell files are payload, not NuGet install scripts. -->
+    <NoWarn>$(NoWarn);NU5111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +30,7 @@
       <PackagePath></PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\README.md" Pack="True" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Guppi.Repl/GuppiReplApp.cs
+++ b/Guppi.Repl/GuppiReplApp.cs
@@ -1,0 +1,34 @@
+using System;
+using Guppi.Core;
+using Guppi.Repl.Skills;
+using Microsoft.Extensions.DependencyInjection;
+using Repl;
+using Repl.Spectre;
+using Repl.Terminal;
+
+namespace Guppi.Repl;
+
+public static class GuppiReplApp
+{
+    public static ReplApp Create(Action<IServiceCollection> configureServices = null)
+    {
+        var app = ReplApp.Create(services =>
+            {
+                services.AddCore();
+                services.AddTransient<ILocalIpAddressProvider, LocalIpAddressProvider>();
+                services.AddSingleton(TimeProvider.System);
+                services.AddSpectreConsole();
+                configureServices?.Invoke(services);
+            })
+            .WithDescription("Experimental Guppi command graph shared by CLI, REPL, and MCP.")
+            .UseTerminalIntegration()
+            .UseDefaultInteractive()
+            .UseCliProfile()
+            .UseSpectreConsole();
+
+        app.Context("utilities", utilities => utilities.MapModule<UtilitiesModule>());
+        app.Context("ip", ip => ip.MapModule<IpModule>());
+
+        return app;
+    }
+}

--- a/Guppi.Repl/GuppiReplApp.cs
+++ b/Guppi.Repl/GuppiReplApp.cs
@@ -7,40 +7,42 @@ using Repl.Mcp;
 using Repl.Spectre;
 using Repl.Terminal;
 
-namespace Guppi.Repl;
-
-public static class GuppiReplApp
+namespace Guppi.Repl
 {
-    public static ReplApp Create(Action<IServiceCollection> configureServices = null)
+
+    public static class GuppiReplApp
     {
-        var app = ReplApp.Create(services =>
-            {
-                services.AddCore();
-                services.AddTransient<ILocalIpAddressProvider, LocalIpAddressProvider>();
-                services.AddSingleton(TimeProvider.System);
-                services.AddSpectreConsole();
-                configureServices?.Invoke(services);
-            })
-            .WithDescription("Experimental Guppi command graph shared by CLI, REPL, and MCP.")
-            .UseTerminalIntegration()
-            .UseDefaultInteractive()
-            .UseCliProfile()
-            .UseSpectreConsole();
-
-        app.UseMcpServer(options =>
+        public static ReplApp Create(Action<IServiceCollection> configureServices = null)
         {
-            options.ServerName = "Guppi";
-            options.ServerVersion = typeof(GuppiReplApp).Assembly.GetName().Version?.ToString() ?? "0.0.0";
-            options.CommandFilter = static command =>
-                command.Path.StartsWith("utilities ", StringComparison.Ordinal)
-                || command.Path.StartsWith("ip ", StringComparison.Ordinal)
-                || command.Path.StartsWith("hue ", StringComparison.Ordinal);
-        });
+            var app = ReplApp.Create(services =>
+                {
+                    services.AddCore();
+                    services.AddTransient<ILocalIpAddressProvider, LocalIpAddressProvider>();
+                    services.AddSingleton(TimeProvider.System);
+                    services.AddSpectreConsole();
+                    configureServices?.Invoke(services);
+                })
+                .WithDescription("Experimental Guppi command graph shared by CLI, REPL, and MCP.")
+                .UseTerminalIntegration()
+                .UseDefaultInteractive()
+                .UseCliProfile()
+                .UseSpectreConsole();
 
-        app.Context("utilities", utilities => utilities.MapModule<UtilitiesModule>());
-        app.Context("ip", ip => ip.MapModule<IpModule>());
-        app.Context("hue", hue => hue.MapModule<HueModule>());
+            app.UseMcpServer(options =>
+            {
+                options.ServerName = "Guppi";
+                options.ServerVersion = typeof(GuppiReplApp).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+                options.CommandFilter = static command =>
+                    command.Path.StartsWith("utilities ", StringComparison.Ordinal)
+                    || command.Path.StartsWith("ip ", StringComparison.Ordinal)
+                    || command.Path.StartsWith("hue ", StringComparison.Ordinal);
+            });
 
-        return app;
+            app.Context("utilities", utilities => utilities.MapModule<UtilitiesModule>());
+            app.Context("ip", ip => ip.MapModule<IpModule>());
+            app.Context("hue", hue => hue.MapModule<HueModule>());
+
+            return app;
+        }
     }
 }

--- a/Guppi.Repl/GuppiReplApp.cs
+++ b/Guppi.Repl/GuppiReplApp.cs
@@ -32,10 +32,7 @@ namespace Guppi.Repl
             {
                 options.ServerName = "Guppi";
                 options.ServerVersion = typeof(GuppiReplApp).Assembly.GetName().Version?.ToString() ?? "0.0.0";
-                options.CommandFilter = static command =>
-                    command.Path.StartsWith("utilities ", StringComparison.Ordinal)
-                    || command.Path.StartsWith("ip ", StringComparison.Ordinal)
-                    || command.Path.StartsWith("hue ", StringComparison.Ordinal);
+                options.CommandFilter = static command => IsMcpCommandAllowed(command.Path);
             });
 
             app.Context("utilities", utilities => utilities.MapModule<UtilitiesModule>());
@@ -44,5 +41,14 @@ namespace Guppi.Repl
 
             return app;
         }
+
+        private static bool IsMcpCommandAllowed(string path) =>
+            path is "utilities date"
+                or "utilities guid"
+                or "ip local"
+                or "hue bridges"
+                or "hue lights"
+                or "hue {light} on"
+                or "hue {light} off";
     }
 }

--- a/Guppi.Repl/GuppiReplApp.cs
+++ b/Guppi.Repl/GuppiReplApp.cs
@@ -3,6 +3,7 @@ using Guppi.Core;
 using Guppi.Repl.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Repl;
+using Repl.Mcp;
 using Repl.Spectre;
 using Repl.Terminal;
 
@@ -26,8 +27,19 @@ public static class GuppiReplApp
             .UseCliProfile()
             .UseSpectreConsole();
 
+        app.UseMcpServer(options =>
+        {
+            options.ServerName = "Guppi";
+            options.ServerVersion = typeof(GuppiReplApp).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+            options.CommandFilter = static command =>
+                command.Path.StartsWith("utilities ", StringComparison.Ordinal)
+                || command.Path.StartsWith("ip ", StringComparison.Ordinal)
+                || command.Path.StartsWith("hue ", StringComparison.Ordinal);
+        });
+
         app.Context("utilities", utilities => utilities.MapModule<UtilitiesModule>());
         app.Context("ip", ip => ip.MapModule<IpModule>());
+        app.Context("hue", hue => hue.MapModule<HueModule>());
 
         return app;
     }

--- a/Guppi.Repl/Program.cs
+++ b/Guppi.Repl/Program.cs
@@ -1,0 +1,1 @@
+return Guppi.Repl.GuppiReplApp.Create().Run(args);

--- a/Guppi.Repl/Results/HueResults.cs
+++ b/Guppi.Repl/Results/HueResults.cs
@@ -1,19 +1,21 @@
-namespace Guppi.Repl.Results;
+namespace Guppi.Repl.Results
+{
 
-public sealed record HueBridgeResult(string BridgeId, string IpAddress);
+    public sealed record HueBridgeResult(string BridgeId, string IpAddress);
 
-public sealed record HueLightResult(
-    string Id,
-    string Name,
-    bool On,
-    byte Brightness,
-    string Color,
-    string Type);
+    public sealed record HueLightResult(
+        string Id,
+        string Name,
+        bool On,
+        byte Brightness,
+        string Color,
+        string Type);
 
-public sealed record HueActionResult(
-    string LightId,
-    string LightName,
-    bool On,
-    byte? Brightness,
-    string Color,
-    string IpAddress);
+    public sealed record HueActionResult(
+        string LightId,
+        string LightName,
+        bool On,
+        byte? Brightness,
+        string Color,
+        string IpAddress);
+}

--- a/Guppi.Repl/Results/HueResults.cs
+++ b/Guppi.Repl/Results/HueResults.cs
@@ -1,0 +1,19 @@
+namespace Guppi.Repl.Results;
+
+public sealed record HueBridgeResult(string BridgeId, string IpAddress);
+
+public sealed record HueLightResult(
+    string Id,
+    string Name,
+    bool On,
+    byte Brightness,
+    string Color,
+    string Type);
+
+public sealed record HueActionResult(
+    string LightId,
+    string LightName,
+    bool On,
+    byte? Brightness,
+    string Color,
+    string IpAddress);

--- a/Guppi.Repl/Results/NetworkResults.cs
+++ b/Guppi.Repl/Results/NetworkResults.cs
@@ -1,3 +1,5 @@
-namespace Guppi.Repl.Results;
+namespace Guppi.Repl.Results
+{
 
-public sealed record LocalIpAddressResult(string InterfaceName, string IpAddress);
+    public sealed record LocalIpAddressResult(string InterfaceName, string IpAddress);
+}

--- a/Guppi.Repl/Results/NetworkResults.cs
+++ b/Guppi.Repl/Results/NetworkResults.cs
@@ -1,0 +1,3 @@
+namespace Guppi.Repl.Results;
+
+public sealed record LocalIpAddressResult(string InterfaceName, string IpAddress);

--- a/Guppi.Repl/Results/UtilityResults.cs
+++ b/Guppi.Repl/Results/UtilityResults.cs
@@ -1,7 +1,9 @@
 using System;
 
-namespace Guppi.Repl.Results;
+namespace Guppi.Repl.Results
+{
 
-public sealed record DateResult(DateOnly Value, bool IsUtc);
+    public sealed record DateResult(DateOnly Value, bool IsUtc);
 
-public sealed record GuidResult(Guid Value);
+    public sealed record GuidResult(Guid Value);
+}

--- a/Guppi.Repl/Results/UtilityResults.cs
+++ b/Guppi.Repl/Results/UtilityResults.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Guppi.Repl.Results;
+
+public sealed record DateResult(DateOnly Value, bool IsUtc);
+
+public sealed record GuidResult(Guid Value);

--- a/Guppi.Repl/Skills/HueModule.cs
+++ b/Guppi.Repl/Skills/HueModule.cs
@@ -11,134 +11,136 @@ using Repl;
 using Repl.Mcp;
 using Repl.Parameters;
 
-namespace Guppi.Repl.Skills;
-
-public sealed class HueModule(IHueLightService hue) : IReplModule
+namespace Guppi.Repl.Skills
 {
-    public void Map(IReplMap map)
+
+    public sealed class HueModule(IHueLightService hue) : IReplModule
     {
-        map.Map("bridges", async (CancellationToken cancellationToken) =>
-            {
-                var bridges = await hue.ListBridges().WaitAsync(cancellationToken).ConfigureAwait(false);
-                return bridges
-                    .Select(bridge => new HueBridgeResult(bridge.BridgeId, bridge.IpAddress))
-                    .ToArray();
-            })
-            .WithDescription("Discover Philips Hue bridges")
-            .ReadOnly()
-            .OpenWorld()
-            .LongRunning();
-
-        map.Map("lights", async (
-                [ReplOption(Aliases = ["-i"])] string ip = null,
-                CancellationToken cancellationToken = default) =>
-            {
-                var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
-                    .WaitAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                return lights.Select(ToResult).ToArray();
-            })
-            .WithDescription("List Philips Hue lights")
-            .ReadOnly()
-            .OpenWorld()
-            .LongRunning();
-
-        map.Map("{light} on", async (
-                string light,
-                [ReplOption(Aliases = ["-i"])] string ip = null,
-                [ReplOption(Aliases = ["-b"])] byte? brightness = null,
-                [ReplOption(Aliases = ["-c"])] string color = null,
-                CancellationToken cancellationToken = default) =>
-            {
-                var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
-                await hue.SetLight(new SetLightCommand
-                {
-                    IpAddress = ip,
-                    Light = lightId,
-                    On = true,
-                    Brightness = brightness,
-                    Color = color,
-                    WaitForUserInput = RejectInteractiveRegistration,
-                })
-                    .WaitAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                return new HueActionResult(target.Id, target.Name, true, brightness, color, ip);
-            })
-            .WithDescription("Turn on a Philips Hue light by ID or name")
-            .WithCompletion("light", CompleteLightsAsync)
-            .OpenWorld()
-            .Idempotent()
-            .LongRunning();
-
-        map.Map("{light} off", async (
-                string light,
-                [ReplOption(Aliases = ["-i"])] string ip = null,
-                CancellationToken cancellationToken = default) =>
-            {
-                var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
-                await hue.SetLight(new SetLightCommand
-                {
-                    IpAddress = ip,
-                    Light = lightId,
-                    Off = true,
-                    WaitForUserInput = RejectInteractiveRegistration,
-                })
-                    .WaitAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                return new HueActionResult(target.Id, target.Name, false, null, null, ip);
-            })
-            .WithDescription("Turn off a Philips Hue light by ID or name")
-            .WithCompletion("light", CompleteLightsAsync)
-            .OpenWorld()
-            .Idempotent()
-            .LongRunning();
-    }
-
-    private async ValueTask<IReadOnlyList<string>> CompleteLightsAsync(
-        CompletionContext _,
-        string input,
-        CancellationToken cancellationToken)
-    {
-        var lights = await hue.ListLights(null, RejectInteractiveRegistration)
-            .WaitAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return lights
-            .SelectMany(light => new[] { light.Name, light.Id })
-            .Where(value => !string.IsNullOrWhiteSpace(value)
-                && value.StartsWith(input, StringComparison.OrdinalIgnoreCase))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-    }
-
-    private async Task<(HueLight Light, uint Id)> ResolveLight(
-        string light,
-        string ip,
-        CancellationToken cancellationToken)
-    {
-        var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
-            .WaitAsync(cancellationToken)
-            .ConfigureAwait(false);
-        var target = lights.FirstOrDefault(candidate =>
-            string.Equals(candidate.Id, light, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(candidate.Name, light, StringComparison.OrdinalIgnoreCase));
-        if (target is null)
+        public void Map(IReplMap map)
         {
-            throw new InvalidOperationException($"Hue light {light} was not found.");
+            map.Map("bridges", async (CancellationToken cancellationToken) =>
+                {
+                    var bridges = await hue.ListBridges().WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return bridges
+                        .Select(bridge => new HueBridgeResult(bridge.BridgeId, bridge.IpAddress))
+                        .ToArray();
+                })
+                .WithDescription("Discover Philips Hue bridges")
+                .ReadOnly()
+                .OpenWorld()
+                .LongRunning();
+
+            map.Map("lights", async (
+                    [ReplOption(Aliases = ["-i"])] string ip = null,
+                    CancellationToken cancellationToken = default) =>
+                {
+                    var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
+                        .WaitAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    return lights.Select(ToResult).ToArray();
+                })
+                .WithDescription("List Philips Hue lights")
+                .ReadOnly()
+                .OpenWorld()
+                .LongRunning();
+
+            map.Map("{light} on", async (
+                    string light,
+                    [ReplOption(Aliases = ["-i"])] string ip = null,
+                    [ReplOption(Aliases = ["-b"])] byte? brightness = null,
+                    [ReplOption(Aliases = ["-c"])] string color = null,
+                    CancellationToken cancellationToken = default) =>
+                {
+                    var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                    await hue.SetLight(new SetLightCommand
+                    {
+                        IpAddress = ip,
+                        Light = lightId,
+                        On = true,
+                        Brightness = brightness,
+                        Color = color,
+                        WaitForUserInput = RejectInteractiveRegistration,
+                    })
+                        .WaitAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    return new HueActionResult(target.Id, target.Name, true, brightness, color, ip);
+                })
+                .WithDescription("Turn on a Philips Hue light by ID or name")
+                .WithCompletion("light", CompleteLightsAsync)
+                .OpenWorld()
+                .Idempotent()
+                .LongRunning();
+
+            map.Map("{light} off", async (
+                    string light,
+                    [ReplOption(Aliases = ["-i"])] string ip = null,
+                    CancellationToken cancellationToken = default) =>
+                {
+                    var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                    await hue.SetLight(new SetLightCommand
+                    {
+                        IpAddress = ip,
+                        Light = lightId,
+                        Off = true,
+                        WaitForUserInput = RejectInteractiveRegistration,
+                    })
+                        .WaitAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    return new HueActionResult(target.Id, target.Name, false, null, null, ip);
+                })
+                .WithDescription("Turn off a Philips Hue light by ID or name")
+                .WithCompletion("light", CompleteLightsAsync)
+                .OpenWorld()
+                .Idempotent()
+                .LongRunning();
         }
 
-        if (!uint.TryParse(target.Id, out var lightId))
+        private async ValueTask<IReadOnlyList<string>> CompleteLightsAsync(
+            CompletionContext _,
+            string input,
+            CancellationToken cancellationToken)
         {
-            throw new InvalidOperationException($"Hue light {target.Name} has invalid ID {target.Id}.");
+            var lights = await hue.ListLights(null, RejectInteractiveRegistration)
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return lights
+                .SelectMany(light => new[] { light.Name, light.Id })
+                .Where(value => !string.IsNullOrWhiteSpace(value)
+                    && value.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
 
-        return (target, lightId);
+        private async Task<(HueLight Light, uint Id)> ResolveLight(
+            string light,
+            string ip,
+            CancellationToken cancellationToken)
+        {
+            var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            var target = lights.FirstOrDefault(candidate =>
+                string.Equals(candidate.Id, light, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(candidate.Name, light, StringComparison.OrdinalIgnoreCase));
+            if (target is null)
+            {
+                throw new InvalidOperationException($"Hue light {light} was not found.");
+            }
+
+            if (!uint.TryParse(target.Id, out var lightId))
+            {
+                throw new InvalidOperationException($"Hue light {target.Name} has invalid ID {target.Id}.");
+            }
+
+            return (target, lightId);
+        }
+
+        private static HueLightResult ToResult(Guppi.Core.Entities.Hue.HueLight light) =>
+            new(light.Id, light.Name, light.On, light.Brightness, light.Color, light.Type);
+
+        private static void RejectInteractiveRegistration(string message) =>
+            throw new InvalidOperationException(
+                $"{message}. Register first with: guppi hue register --ip <address>.");
     }
-
-    private static HueLightResult ToResult(Guppi.Core.Entities.Hue.HueLight light) =>
-        new(light.Id, light.Name, light.On, light.Brightness, light.Color, light.Type);
-
-    private static void RejectInteractiveRegistration(string message) =>
-        throw new InvalidOperationException(
-            $"{message}. Register first with: guppi hue register --ip <address>.");
 }

--- a/Guppi.Repl/Skills/HueModule.cs
+++ b/Guppi.Repl/Skills/HueModule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Guppi.Core.Entities.Hue;
 using Guppi.Core.Interfaces.Services;
 using Guppi.Core.Services.Hue;
 using Guppi.Repl.Results;
+using Microsoft.Extensions.DependencyInjection;
 using Repl;
 using Repl.Mcp;
 using Repl.Parameters;
@@ -14,13 +16,15 @@ using Repl.Parameters;
 namespace Guppi.Repl.Skills
 {
 
-    public sealed class HueModule(IHueLightService hue) : IReplModule
+    public sealed class HueModule(IServiceScopeFactory scopeFactory) : IReplModule
     {
         public void Map(IReplMap map)
         {
             map.Map("bridges", async (CancellationToken cancellationToken) =>
                 {
-                    var bridges = await hue.ListBridges().WaitAsync(cancellationToken).ConfigureAwait(false);
+                    using var scope = scopeFactory.CreateScope();
+                    var hue = scope.ServiceProvider.GetRequiredService<IHueLightService>();
+                    var bridges = await hue.ListBridges(cancellationToken).ConfigureAwait(false);
                     return bridges
                         .Select(bridge => new HueBridgeResult(bridge.BridgeId, bridge.IpAddress))
                         .ToArray();
@@ -34,8 +38,9 @@ namespace Guppi.Repl.Skills
                     [ReplOption(Aliases = ["-i"])] string ip = null,
                     CancellationToken cancellationToken = default) =>
                 {
-                    var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
-                        .WaitAsync(cancellationToken)
+                    using var scope = scopeFactory.CreateScope();
+                    var hue = scope.ServiceProvider.GetRequiredService<IHueLightService>();
+                    var lights = await hue.ListLights(ip, RejectInteractiveRegistration, cancellationToken)
                         .ConfigureAwait(false);
                     return lights.Select(ToResult).ToArray();
                 })
@@ -47,26 +52,30 @@ namespace Guppi.Repl.Skills
             map.Map("{light} on", async (
                     string light,
                     [ReplOption(Aliases = ["-i"])] string ip = null,
-                    [ReplOption(Aliases = ["-b"])] byte? brightness = null,
+                    [Description("Brightness percentage from 0 to 100.")]
+                    [ReplOption(Aliases = ["-b"])] int brightness = -1,
                     [ReplOption(Aliases = ["-c"])] string color = null,
                     CancellationToken cancellationToken = default) =>
                 {
-                    var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                    var normalizedBrightness = NormalizeBrightness(brightness);
+                    using var scope = scopeFactory.CreateScope();
+                    var hue = scope.ServiceProvider.GetRequiredService<IHueLightService>();
+                    var (target, lightId) = await ResolveLight(hue, light, ip, cancellationToken).ConfigureAwait(false);
                     await hue.SetLight(new SetLightCommand
                     {
                         IpAddress = ip,
                         Light = lightId,
                         On = true,
-                        Brightness = brightness,
+                        Brightness = normalizedBrightness,
                         Color = color,
                         WaitForUserInput = RejectInteractiveRegistration,
-                    })
-                        .WaitAsync(cancellationToken)
+                    }, cancellationToken)
                         .ConfigureAwait(false);
-                    return new HueActionResult(target.Id, target.Name, true, brightness, color, ip);
+                    return new HueActionResult(target.Id, target.Name, true, normalizedBrightness, color, ip);
                 })
                 .WithDescription("Turn on a Philips Hue light by ID or name")
                 .WithCompletion("light", CompleteLightsAsync)
+                .Destructive()
                 .OpenWorld()
                 .Idempotent()
                 .LongRunning();
@@ -76,20 +85,22 @@ namespace Guppi.Repl.Skills
                     [ReplOption(Aliases = ["-i"])] string ip = null,
                     CancellationToken cancellationToken = default) =>
                 {
-                    var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                    using var scope = scopeFactory.CreateScope();
+                    var hue = scope.ServiceProvider.GetRequiredService<IHueLightService>();
+                    var (target, lightId) = await ResolveLight(hue, light, ip, cancellationToken).ConfigureAwait(false);
                     await hue.SetLight(new SetLightCommand
                     {
                         IpAddress = ip,
                         Light = lightId,
                         Off = true,
                         WaitForUserInput = RejectInteractiveRegistration,
-                    })
-                        .WaitAsync(cancellationToken)
+                    }, cancellationToken)
                         .ConfigureAwait(false);
                     return new HueActionResult(target.Id, target.Name, false, null, null, ip);
                 })
                 .WithDescription("Turn off a Philips Hue light by ID or name")
                 .WithCompletion("light", CompleteLightsAsync)
+                .Destructive()
                 .OpenWorld()
                 .Idempotent()
                 .LongRunning();
@@ -100,8 +111,9 @@ namespace Guppi.Repl.Skills
             string input,
             CancellationToken cancellationToken)
         {
-            var lights = await hue.ListLights(null, RejectInteractiveRegistration)
-                .WaitAsync(cancellationToken)
+            using var scope = scopeFactory.CreateScope();
+            var hue = scope.ServiceProvider.GetRequiredService<IHueLightService>();
+            var lights = await hue.ListLights(null, RejectInteractiveRegistration, cancellationToken)
                 .ConfigureAwait(false);
             return lights
                 .SelectMany(light => new[] { light.Name, light.Id })
@@ -112,17 +124,40 @@ namespace Guppi.Repl.Skills
                 .ToArray();
         }
 
-        private async Task<(HueLight Light, uint Id)> ResolveLight(
+        private static async Task<(HueLight Light, uint Id)> ResolveLight(
+            IHueLightService hue,
             string light,
             string ip,
             CancellationToken cancellationToken)
         {
-            var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
-                .WaitAsync(cancellationToken)
+            var lights = await hue.ListLights(ip, RejectInteractiveRegistration, cancellationToken)
                 .ConfigureAwait(false);
-            var target = lights.FirstOrDefault(candidate =>
-                string.Equals(candidate.Id, light, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(candidate.Name, light, StringComparison.OrdinalIgnoreCase));
+            HueLight target;
+            if (uint.TryParse(light, out _))
+            {
+                target = lights.SingleOrDefault(candidate =>
+                    string.Equals(candidate.Id, light, StringComparison.Ordinal));
+            }
+            else
+            {
+                var matches = lights
+                    .Where(candidate => string.Equals(
+                        candidate.Name,
+                        light,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                if (matches.Length > 1)
+                {
+                    var candidateIds = string.Join(", ", matches
+                        .Select(candidate => candidate.Id)
+                        .OrderBy(id => id, StringComparer.Ordinal));
+                    throw new InvalidOperationException(
+                        $"Hue light name {light} is ambiguous. Use one of these IDs: {candidateIds}.");
+                }
+
+                target = matches.SingleOrDefault();
+            }
+
             if (target is null)
             {
                 throw new InvalidOperationException($"Hue light {light} was not found.");
@@ -136,7 +171,22 @@ namespace Guppi.Repl.Skills
             return (target, lightId);
         }
 
-        private static HueLightResult ToResult(Guppi.Core.Entities.Hue.HueLight light) =>
+        private static byte? NormalizeBrightness(int brightness)
+        {
+            if (brightness == -1)
+            {
+                return null;
+            }
+
+            if (brightness is < 0 or > 100)
+            {
+                throw new InvalidOperationException("Brightness must be between 0 and 100 percent.");
+            }
+
+            return (byte)brightness;
+        }
+
+        private static HueLightResult ToResult(HueLight light) =>
             new(light.Id, light.Name, light.On, light.Brightness, light.Color, light.Type);
 
         private static void RejectInteractiveRegistration(string message) =>

--- a/Guppi.Repl/Skills/HueModule.cs
+++ b/Guppi.Repl/Skills/HueModule.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Guppi.Core.Entities.Hue;
+using Guppi.Core.Interfaces.Services;
+using Guppi.Core.Services.Hue;
+using Guppi.Repl.Results;
+using Repl;
+using Repl.Mcp;
+using Repl.Parameters;
+
+namespace Guppi.Repl.Skills;
+
+public sealed class HueModule(IHueLightService hue) : IReplModule
+{
+    public void Map(IReplMap map)
+    {
+        map.Map("bridges", async (CancellationToken cancellationToken) =>
+            {
+                var bridges = await hue.ListBridges().WaitAsync(cancellationToken).ConfigureAwait(false);
+                return bridges
+                    .Select(bridge => new HueBridgeResult(bridge.BridgeId, bridge.IpAddress))
+                    .ToArray();
+            })
+            .WithDescription("Discover Philips Hue bridges")
+            .ReadOnly()
+            .OpenWorld()
+            .LongRunning();
+
+        map.Map("lights", async (
+                [ReplOption(Aliases = ["-i"])] string ip = null,
+                CancellationToken cancellationToken = default) =>
+            {
+                var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return lights.Select(ToResult).ToArray();
+            })
+            .WithDescription("List Philips Hue lights")
+            .ReadOnly()
+            .OpenWorld()
+            .LongRunning();
+
+        map.Map("{light} on", async (
+                string light,
+                [ReplOption(Aliases = ["-i"])] string ip = null,
+                [ReplOption(Aliases = ["-b"])] byte? brightness = null,
+                [ReplOption(Aliases = ["-c"])] string color = null,
+                CancellationToken cancellationToken = default) =>
+            {
+                var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                await hue.SetLight(new SetLightCommand
+                {
+                    IpAddress = ip,
+                    Light = lightId,
+                    On = true,
+                    Brightness = brightness,
+                    Color = color,
+                    WaitForUserInput = RejectInteractiveRegistration,
+                })
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return new HueActionResult(target.Id, target.Name, true, brightness, color, ip);
+            })
+            .WithDescription("Turn on a Philips Hue light by ID or name")
+            .WithCompletion("light", CompleteLightsAsync)
+            .OpenWorld()
+            .Idempotent()
+            .LongRunning();
+
+        map.Map("{light} off", async (
+                string light,
+                [ReplOption(Aliases = ["-i"])] string ip = null,
+                CancellationToken cancellationToken = default) =>
+            {
+                var (target, lightId) = await ResolveLight(light, ip, cancellationToken).ConfigureAwait(false);
+                await hue.SetLight(new SetLightCommand
+                {
+                    IpAddress = ip,
+                    Light = lightId,
+                    Off = true,
+                    WaitForUserInput = RejectInteractiveRegistration,
+                })
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return new HueActionResult(target.Id, target.Name, false, null, null, ip);
+            })
+            .WithDescription("Turn off a Philips Hue light by ID or name")
+            .WithCompletion("light", CompleteLightsAsync)
+            .OpenWorld()
+            .Idempotent()
+            .LongRunning();
+    }
+
+    private async ValueTask<IReadOnlyList<string>> CompleteLightsAsync(
+        CompletionContext _,
+        string input,
+        CancellationToken cancellationToken)
+    {
+        var lights = await hue.ListLights(null, RejectInteractiveRegistration)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return lights
+            .SelectMany(light => new[] { light.Name, light.Id })
+            .Where(value => !string.IsNullOrWhiteSpace(value)
+                && value.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private async Task<(HueLight Light, uint Id)> ResolveLight(
+        string light,
+        string ip,
+        CancellationToken cancellationToken)
+    {
+        var lights = await hue.ListLights(ip, RejectInteractiveRegistration)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var target = lights.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, light, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(candidate.Name, light, StringComparison.OrdinalIgnoreCase));
+        if (target is null)
+        {
+            throw new InvalidOperationException($"Hue light {light} was not found.");
+        }
+
+        if (!uint.TryParse(target.Id, out var lightId))
+        {
+            throw new InvalidOperationException($"Hue light {target.Name} has invalid ID {target.Id}.");
+        }
+
+        return (target, lightId);
+    }
+
+    private static HueLightResult ToResult(Guppi.Core.Entities.Hue.HueLight light) =>
+        new(light.Id, light.Name, light.On, light.Brightness, light.Color, light.Type);
+
+    private static void RejectInteractiveRegistration(string message) =>
+        throw new InvalidOperationException(
+            $"{message}. Register first with: guppi hue register --ip <address>.");
+}

--- a/Guppi.Repl/Skills/IpModule.cs
+++ b/Guppi.Repl/Skills/IpModule.cs
@@ -1,14 +1,16 @@
 using Repl;
 using Repl.Mcp;
 
-namespace Guppi.Repl.Skills;
-
-public sealed class IpModule(ILocalIpAddressProvider addresses) : IReplModule
+namespace Guppi.Repl.Skills
 {
-    public void Map(IReplMap map)
+
+    public sealed class IpModule(ILocalIpAddressProvider addresses) : IReplModule
     {
-        map.Map("local", () => addresses.GetLocalAddresses())
-            .WithDescription("List active local IPv4 addresses")
-            .ReadOnly();
+        public void Map(IReplMap map)
+        {
+            map.Map("local", () => addresses.GetLocalAddresses())
+                .WithDescription("List active local IPv4 addresses")
+                .ReadOnly();
+        }
     }
 }

--- a/Guppi.Repl/Skills/IpModule.cs
+++ b/Guppi.Repl/Skills/IpModule.cs
@@ -1,0 +1,14 @@
+using Repl;
+using Repl.Mcp;
+
+namespace Guppi.Repl.Skills;
+
+public sealed class IpModule(ILocalIpAddressProvider addresses) : IReplModule
+{
+    public void Map(IReplMap map)
+    {
+        map.Map("local", () => addresses.GetLocalAddresses())
+            .WithDescription("List active local IPv4 addresses")
+            .ReadOnly();
+    }
+}

--- a/Guppi.Repl/Skills/LocalIpAddressProvider.cs
+++ b/Guppi.Repl/Skills/LocalIpAddressProvider.cs
@@ -4,20 +4,22 @@ using System.Net.Sockets;
 using Guppi.Core.Interfaces.Services;
 using Guppi.Repl.Results;
 
-namespace Guppi.Repl.Skills;
-
-public interface ILocalIpAddressProvider
+namespace Guppi.Repl.Skills
 {
-    LocalIpAddressResult[] GetLocalAddresses();
-}
 
-public sealed class LocalIpAddressProvider(IIPService service) : ILocalIpAddressProvider
-{
-    public LocalIpAddressResult[] GetLocalAddresses() =>
-        service.GetNetworkInterfaces()
-            .Where(network => network.OperationalStatus == OperationalStatus.Up)
-            .SelectMany(network => network.GetIPProperties().UnicastAddresses
-                .Where(address => address.Address.AddressFamily == AddressFamily.InterNetwork)
-                .Select(address => new LocalIpAddressResult(network.Name, address.Address.ToString())))
-            .ToArray();
+    public interface ILocalIpAddressProvider
+    {
+        LocalIpAddressResult[] GetLocalAddresses();
+    }
+
+    public sealed class LocalIpAddressProvider(IIPService service) : ILocalIpAddressProvider
+    {
+        public LocalIpAddressResult[] GetLocalAddresses() =>
+            service.GetNetworkInterfaces()
+                .Where(network => network.OperationalStatus == OperationalStatus.Up)
+                .SelectMany(network => network.GetIPProperties().UnicastAddresses
+                    .Where(address => address.Address.AddressFamily == AddressFamily.InterNetwork)
+                    .Select(address => new LocalIpAddressResult(network.Name, address.Address.ToString())))
+                .ToArray();
+    }
 }

--- a/Guppi.Repl/Skills/LocalIpAddressProvider.cs
+++ b/Guppi.Repl/Skills/LocalIpAddressProvider.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Guppi.Core.Interfaces.Services;
+using Guppi.Repl.Results;
+
+namespace Guppi.Repl.Skills;
+
+public interface ILocalIpAddressProvider
+{
+    LocalIpAddressResult[] GetLocalAddresses();
+}
+
+public sealed class LocalIpAddressProvider(IIPService service) : ILocalIpAddressProvider
+{
+    public LocalIpAddressResult[] GetLocalAddresses() =>
+        service.GetNetworkInterfaces()
+            .Where(network => network.OperationalStatus == OperationalStatus.Up)
+            .SelectMany(network => network.GetIPProperties().UnicastAddresses
+                .Where(address => address.Address.AddressFamily == AddressFamily.InterNetwork)
+                .Select(address => new LocalIpAddressResult(network.Name, address.Address.ToString())))
+            .ToArray();
+}

--- a/Guppi.Repl/Skills/UtilitiesModule.cs
+++ b/Guppi.Repl/Skills/UtilitiesModule.cs
@@ -1,0 +1,25 @@
+using System;
+using Guppi.Repl.Results;
+using Repl;
+using Repl.Mcp;
+using Repl.Parameters;
+
+namespace Guppi.Repl.Skills;
+
+public sealed class UtilitiesModule(TimeProvider timeProvider) : IReplModule
+{
+    public void Map(IReplMap map)
+    {
+        map.Map("date", ([ReplOption(Aliases = ["-u"])] bool utc = false) =>
+            {
+                var now = utc ? timeProvider.GetUtcNow() : timeProvider.GetLocalNow();
+                return new DateResult(DateOnly.FromDateTime(now.DateTime), utc);
+            })
+            .WithDescription("Get the current date")
+            .ReadOnly();
+
+        map.Map("guid", static () => new GuidResult(Guid.NewGuid()))
+            .WithDescription("Create a new GUID")
+            .ReadOnly();
+    }
+}

--- a/Guppi.Repl/Skills/UtilitiesModule.cs
+++ b/Guppi.Repl/Skills/UtilitiesModule.cs
@@ -4,22 +4,24 @@ using Repl;
 using Repl.Mcp;
 using Repl.Parameters;
 
-namespace Guppi.Repl.Skills;
-
-public sealed class UtilitiesModule(TimeProvider timeProvider) : IReplModule
+namespace Guppi.Repl.Skills
 {
-    public void Map(IReplMap map)
-    {
-        map.Map("date", ([ReplOption(Aliases = ["-u"])] bool utc = false) =>
-            {
-                var now = utc ? timeProvider.GetUtcNow() : timeProvider.GetLocalNow();
-                return new DateResult(DateOnly.FromDateTime(now.DateTime), utc);
-            })
-            .WithDescription("Get the current date")
-            .ReadOnly();
 
-        map.Map("guid", static () => new GuidResult(Guid.NewGuid()))
-            .WithDescription("Create a new GUID")
-            .ReadOnly();
+    public sealed class UtilitiesModule(TimeProvider timeProvider) : IReplModule
+    {
+        public void Map(IReplMap map)
+        {
+            map.Map("date", ([ReplOption(Aliases = ["-u"])] bool utc = false) =>
+                {
+                    var now = utc ? timeProvider.GetUtcNow() : timeProvider.GetLocalNow();
+                    return new DateResult(DateOnly.FromDateTime(now.DateTime), utc);
+                })
+                .WithDescription("Get the current date")
+                .ReadOnly();
+
+            map.Map("guid", static () => new GuidResult(Guid.NewGuid()))
+                .WithDescription("Create a new GUID")
+                .ReadOnly();
+        }
     }
 }

--- a/Guppi.slnx
+++ b/Guppi.slnx
@@ -25,4 +25,6 @@
   <Project Path="Guppi.Core/Guppi.Core.csproj" />
   <Project Path="Guppi.Tests/Guppi.Tests.csproj" />
   <Project Path="Guppi.MCP/Guppi.MCP.csproj" />
+  <Project Path="Guppi.Repl/Guppi.Repl.csproj" />
+  <Project Path="Guppi.Repl.Tests/Guppi.Repl.Tests.csproj" />
 </Solution>

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ The pilot currently includes:
 - `hue {light} on [--ip|-i] [--brightness|-b] [--color|-c]`
 - `hue {light} off [--ip|-i]`
 
+Hue brightness is a percentage from 0 to 100. Numeric light arguments match IDs
+first; names are case-insensitive and must be unique.
+
 Use it as a one-shot CLI:
 
 ```sh
@@ -166,7 +169,7 @@ Or enter a persistent context:
 $ guppi.repl
 > hue
 [hue]> lights
-[hue]> kitchen on --brightness 128 --color red
+[hue]> kitchen on --brightness 80 --color red
 [hue]> ..
 > utilities guid
 ```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,60 @@ To get the information to configure;
 2. Use [Google Maps](https://google.ca/maps) to get your Latitude and Longitude.
 3. Once you've configured an initial location, you can use the `--location` option to find the weather for additional locations and to use their latitude and longitude for the configuration.
 
+## Experimental Repl Pilot
+
+`Guppi.Repl` is an additive pilot built with Repl Toolkit `0.11.0-dev.181`. It maps a
+small command graph once and exposes it as a one-shot CLI, an interactive REPL, and an
+MCP server. It does not replace or change the existing `guppi` or `guppi.mcp` tools.
+
+The pilot currently includes:
+
+- `utilities date [--utc|-u]`
+- `utilities guid`
+- `ip local`
+- `hue bridges`
+- `hue lights [--ip|-i]`
+- `hue {light} on [--ip|-i] [--brightness|-b] [--color|-c]`
+- `hue {light} off [--ip|-i]`
+
+Use it as a one-shot CLI:
+
+```sh
+guppi.repl utilities date --utc --json
+guppi.repl ip local --yaml
+```
+
+Or enter a persistent context:
+
+```text
+$ guppi.repl
+> hue
+[hue]> lights
+[hue]> kitchen on --brightness 128 --color red
+[hue]> ..
+> utilities guid
+```
+
+Hue accepts either a numeric light ID or a case-insensitive name. Dynamic Hue completion
+is enabled in the interactive REPL only. If bridge registration is required, use the
+existing interactive flow first: `guppi hue register --ip <address>`.
+
+The same graph is available over MCP STDIO:
+
+```json
+{
+  "mcpServers": {
+    "guppi-repl": {
+      "command": "guppi.repl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+MCP exposure is deliberately allow-listed to the pilot commands. The experimental
+`dotnet-guppi-repl` package is locally packable but is not published by the existing CI.
+
 ## MCP Server
 
 Guppi includes an MCP (Model Context Protocol) server that exposes Guppi skills as tools
@@ -185,6 +239,7 @@ command line from the solution root;
 ```sh
 dotnet tool install -g --add-source ./Guppi.Console/nupkg dotnet-guppi
 dotnet tool install -g --add-source ./Guppi.MCP/nupkg dotnet-guppi-mcp
+dotnet tool install -g --add-source ./Guppi.Repl/nupkg dotnet-guppi-repl
 ```
 
 To update from a previous version,
@@ -192,6 +247,7 @@ To update from a previous version,
 ```sh
 dotnet tool update -g --add-source ./Guppi.Console/nupkg dotnet-guppi
 dotnet tool update -g --add-source ./Guppi.MCP/nupkg dotnet-guppi-mcp
+dotnet tool update -g --add-source ./Guppi.Repl/nupkg dotnet-guppi-repl
 ```
 
 ### Installing from GitHub Packages

--- a/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
+++ b/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
@@ -1,0 +1,75 @@
+# Additive Repl Pilot Implementation Plan
+
+**Goal:** Add a separate `Guppi.Repl` pilot that maps selected capabilities once and exposes them as CLI, interactive REPL, and MCP.
+
+**Architecture:** Keep existing heads intact. Add one Repl composition root and one `IReplModule` per pilot skill, typed records, handler-parameter DI, and `Repl.Testing` graph tests.
+
+**Tech Stack:** .NET 10, Repl, Repl.Mcp, Repl.Spectre, and Repl.Testing `0.11.0-dev.181`, NUnit 4, FluentAssertions 8.
+
+**Design:** [2026-07-15-repl-pilot-design.md](../specs/2026-07-15-repl-pilot-design.md)
+
+## Task 1: Test and project infrastructure
+
+- [ ] Write the first graph test against the wished-for `GuppiReplApp.Create()` API.
+- [ ] Verify RED because the app does not exist.
+- [ ] Add minimal `Guppi.Repl`, `Guppi.Repl.Tests`, packages, and solution entries.
+- [ ] Verify the test now fails because `utilities date` is unmapped.
+
+## Task 2: `utilities date`
+
+- [ ] Test a fixed UTC date through `ReplTestHost` and typed `DateResult`; verify RED.
+- [ ] Register `TimeProvider`, mount `UtilitiesModule`, map typed `--utc`; verify GREEN.
+
+## Task 3: `utilities guid`
+
+- [ ] Test a typed non-empty `GuidResult`; verify RED.
+- [ ] Map the read-only command; verify GREEN.
+
+## Task 4: `ip local`
+
+- [ ] Test with a deterministic fake `IIPService`; verify RED.
+- [ ] Map active IPv4 interfaces to `LocalIpAddressResult`; annotate read-only; verify GREEN.
+
+## Task 5: Hue discovery
+
+- [ ] Test typed `hue bridges`; RED, implement, GREEN.
+- [ ] Test typed `hue lights --ip ...`; RED, implement, GREEN.
+- [ ] Map domain entities to stable records and add read-only, open-world, and long-running metadata.
+
+## Task 6: Natural Hue controls
+
+- [ ] Test `hue kitchen on` name-to-ID resolution; RED, implement, GREEN.
+- [ ] Test numeric IDs, case-insensitive names, and `hue kitchen off` in separate slices.
+- [ ] Test semantic unknown-light failure without sending a command.
+- [ ] Add typed IP, brightness, and color options plus mutation annotations.
+
+## Task 7: Hue completion
+
+- [ ] Test fake-backed name and ID completion; verify RED.
+- [ ] Attach interactive-only `WithCompletion("light", ...)`; verify GREEN.
+
+## Task 8: Persistent REPL
+
+- [ ] Open a `ReplTestHost` session.
+- [ ] Enter `hue`, run `lights`, run `kitchen on`, navigate back, then run `utilities date`.
+- [ ] Assert typed results and context behavior with no real device access.
+
+## Task 9: MCP
+
+- [ ] Enable `UseMcpServer()` and keep CLI and REPL tests green.
+- [ ] Launch STDIO MCP, send initialize plus `tools/list`, and verify pilot tools and schemas.
+
+## Task 10: Packaging
+
+- [ ] Pack Release, inspect the package, and install into a temporary tool path.
+- [ ] Smoke-test installed CLI JSON and MCP discovery.
+
+## Task 11: Documentation
+
+- [ ] Update `README.md` and `AGENTS.md` for additive and experimental scope, commands, conventions, and non-publication.
+
+## Task 12: Full verification and PR
+
+- [ ] Release build, full tests, CLI, REPL, MCP, completion, and package smoke tests.
+- [ ] Format and analyzers, `git diff --check`, security and scope review.
+- [ ] Commit logical increments, push `agent/repl-pilot`, and open a verified draft PR to `rprouse/guppi:main` with exact evidence.

--- a/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
+++ b/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
@@ -73,3 +73,13 @@
 - [x] Release build, full tests, CLI, REPL, MCP, completion, and package smoke tests.
 - [x] Format and analyzers, `git diff --check`, security and scope review.
 - [x] Push `agent/repl-pilot` and open a verified draft PR to `rprouse/guppi:main` with exact evidence.
+
+## Task 13: Post-review hardening
+
+- [x] Replace context-prefix MCP exposure with an exact seven-command allow-list.
+- [x] Resolve a fresh Hue service/provider per invocation and cover the lifetime with a regression test.
+- [x] Prioritize numeric Hue IDs and reject duplicate case-insensitive names with candidate IDs.
+- [x] Model brightness as an integer percentage, validate 0–100, and assert its live MCP schema.
+- [x] Mark Hue mutations explicitly destructive and assert their MCP annotations.
+- [x] Automate MCP STDIO initialize, exact tool listing, schema validation, tool call, and JSON-only stdout.
+- [x] Propagate cancellation through Core and Hue discovery without `WaitAsync` around non-cancellable Q42 mutations.

--- a/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
+++ b/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
@@ -2,7 +2,7 @@
 
 **Goal:** Add a separate `Guppi.Repl` pilot that maps selected capabilities once and exposes them as CLI, interactive REPL, and MCP.
 
-**Architecture:** Keep existing heads intact. Add one Repl composition root and one `IReplModule` per pilot skill, typed records, handler-parameter DI, and `Repl.Testing` graph tests.
+**Architecture:** Keep existing heads intact. Add one Repl composition root and one constructor-injected `IReplModule` per pilot skill, typed records, and `Repl.Testing` graph tests.
 
 **Tech Stack:** .NET 10, Repl, Repl.Mcp, Repl.Spectre, and Repl.Testing `0.11.0-dev.181`, NUnit 4, FluentAssertions 8.
 
@@ -10,66 +10,66 @@
 
 ## Task 1: Test and project infrastructure
 
-- [ ] Write the first graph test against the wished-for `GuppiReplApp.Create()` API.
-- [ ] Verify RED because the app does not exist.
-- [ ] Add minimal `Guppi.Repl`, `Guppi.Repl.Tests`, packages, and solution entries.
-- [ ] Verify the test now fails because `utilities date` is unmapped.
+- [x] Write the first graph test against the wished-for `GuppiReplApp.Create()` API.
+- [x] Verify RED because the app does not exist.
+- [x] Add minimal `Guppi.Repl`, `Guppi.Repl.Tests`, packages, and solution entries.
+- [x] Verify the test now fails because `utilities date` is unmapped.
 
 ## Task 2: `utilities date`
 
-- [ ] Test a fixed UTC date through `ReplTestHost` and typed `DateResult`; verify RED.
-- [ ] Register `TimeProvider`, mount `UtilitiesModule`, map typed `--utc`; verify GREEN.
+- [x] Test a fixed UTC date through `ReplTestHost` and typed `DateResult`; verify RED.
+- [x] Register `TimeProvider`, mount `UtilitiesModule`, map typed `--utc`; verify GREEN.
 
 ## Task 3: `utilities guid`
 
-- [ ] Test a typed non-empty `GuidResult`; verify RED.
-- [ ] Map the read-only command; verify GREEN.
+- [x] Test a typed non-empty `GuidResult`; verify RED.
+- [x] Map the read-only command; verify GREEN.
 
 ## Task 4: `ip local`
 
-- [ ] Test with a deterministic fake `IIPService`; verify RED.
-- [ ] Map active IPv4 interfaces to `LocalIpAddressResult`; annotate read-only; verify GREEN.
+- [x] Test with a deterministic fake `ILocalIpAddressProvider`; verify RED.
+- [x] Map active IPv4 interfaces to `LocalIpAddressResult`; annotate read-only; verify GREEN.
 
 ## Task 5: Hue discovery
 
-- [ ] Test typed `hue bridges`; RED, implement, GREEN.
-- [ ] Test typed `hue lights --ip ...`; RED, implement, GREEN.
-- [ ] Map domain entities to stable records and add read-only, open-world, and long-running metadata.
+- [x] Test typed `hue bridges`; RED, implement, GREEN.
+- [x] Test typed `hue lights --ip ...`; RED, implement, GREEN.
+- [x] Map domain entities to stable records and add read-only, open-world, and long-running metadata.
 
 ## Task 6: Natural Hue controls
 
-- [ ] Test `hue kitchen on` name-to-ID resolution; RED, implement, GREEN.
-- [ ] Test numeric IDs, case-insensitive names, and `hue kitchen off` in separate slices.
-- [ ] Test semantic unknown-light failure without sending a command.
-- [ ] Add typed IP, brightness, and color options plus mutation annotations.
+- [x] Test `hue kitchen on` name-to-ID resolution; RED, implement, GREEN.
+- [x] Test numeric IDs, case-insensitive names, and `hue kitchen off` in separate slices.
+- [x] Test semantic unknown-light failure without sending a command.
+- [x] Add typed IP, brightness, and color options plus mutation annotations.
 
 ## Task 7: Hue completion
 
-- [ ] Test fake-backed name and ID completion; verify RED.
-- [ ] Attach interactive-only `WithCompletion("light", ...)`; verify GREEN.
+- [x] Test fake-backed name and ID completion; verify RED.
+- [x] Attach interactive-only `WithCompletion("light", ...)`; verify GREEN.
 
 ## Task 8: Persistent REPL
 
-- [ ] Open a `ReplTestHost` session.
-- [ ] Enter `hue`, run `lights`, run `kitchen on`, navigate back, then run `utilities date`.
-- [ ] Assert typed results and context behavior with no real device access.
+- [x] Confirm `ReplTestHost` hosted invocations do not preserve interactive context scope.
+- [x] Run one real redirected interactive loop: enter `hue`, list lights, turn on `kitchen`, navigate back, then run `utilities date`.
+- [x] Assert context behavior and fake-backed device calls with no real device access.
 
 ## Task 9: MCP
 
-- [ ] Enable `UseMcpServer()` and keep CLI and REPL tests green.
-- [ ] Launch STDIO MCP, send initialize plus `tools/list`, and verify pilot tools and schemas.
+- [x] Enable `UseMcpServer()` and keep CLI and REPL tests green.
+- [x] Launch STDIO MCP, send initialize plus `tools/list`, and verify pilot tools and schemas.
 
 ## Task 10: Packaging
 
-- [ ] Pack Release, inspect the package, and install into a temporary tool path.
-- [ ] Smoke-test installed CLI JSON and MCP discovery.
+- [x] Pack Release, inspect the package, and install into a temporary tool path.
+- [x] Smoke-test installed CLI JSON and MCP discovery.
 
 ## Task 11: Documentation
 
-- [ ] Update `README.md` and `AGENTS.md` for additive and experimental scope, commands, conventions, and non-publication.
+- [x] Update `README.md` and `AGENTS.md` for additive and experimental scope, commands, conventions, and non-publication.
 
 ## Task 12: Full verification and PR
 
-- [ ] Release build, full tests, CLI, REPL, MCP, completion, and package smoke tests.
-- [ ] Format and analyzers, `git diff --check`, security and scope review.
-- [ ] Commit logical increments, push `agent/repl-pilot`, and open a verified draft PR to `rprouse/guppi:main` with exact evidence.
+- [x] Release build, full tests, CLI, REPL, MCP, completion, and package smoke tests.
+- [x] Format and analyzers, `git diff --check`, security and scope review.
+- [ ] Push `agent/repl-pilot` and open a verified draft PR to `rprouse/guppi:main` with exact evidence.

--- a/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
+++ b/docs/superpowers/plans/2026-07-15-repl-pilot-plan.md
@@ -72,4 +72,4 @@
 
 - [x] Release build, full tests, CLI, REPL, MCP, completion, and package smoke tests.
 - [x] Format and analyzers, `git diff --check`, security and scope review.
-- [ ] Push `agent/repl-pilot` and open a verified draft PR to `rprouse/guppi:main` with exact evidence.
+- [x] Push `agent/repl-pilot` and open a verified draft PR to `rprouse/guppi:main` with exact evidence.

--- a/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
+++ b/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
@@ -1,0 +1,113 @@
+# Additive Repl Pilot for Guppi
+
+**Date:** 2026-07-15
+**Version:** 9.2.0 (unchanged)
+**Status:** Approved for implementation
+
+## Overview
+
+Add a new `Guppi.Repl` executable as a vertical pilot of Repl Toolkit without changing or removing the existing `Guppi.Console` and `Guppi.MCP` applications. The pilot maps a deliberately small set of operations once and exposes the same command graph as a one-shot CLI, an interactive REPL, and an MCP server.
+
+The pilot uses the latest published Repl prerelease verified on GitHub Releases and NuGet on 2026-07-15: `0.11.0-dev.181`.
+
+## Problem
+
+```text
+Business services
+   ├── System.CommandLine skill wiring
+   └── separate MCP tool wiring
+```
+
+The pilot tests the intended Repl model:
+
+```text
+Business services
+   └── one Repl command graph
+         ├── CLI
+         ├── interactive REPL
+         └── MCP
+```
+
+## Goals
+
+- Prove one typed command graph can serve CLI, REPL, and MCP.
+- Keep existing executables and non-pilot skills unchanged.
+- Preserve skill organization with one `IReplModule` per pilot skill.
+- Return typed, JSON-friendly records instead of surface-specific strings.
+- Support natural scoped use:
+
+  ```text
+  guppi.repl
+  > utilities date
+  > hue
+  [hue]> lights
+  [hue]> kitchen on
+  ```
+
+- Demonstrate DI, cancellation, behavioral annotations, dynamic completion, structured output, and `Repl.Testing`.
+- Keep device/network tests deterministic through injected fakes.
+
+## Non-Goals
+
+- Migrating all skills.
+- Removing or changing `Guppi.Console`, `Guppi.MCP`, or their packages.
+- Publishing the pilot package from CI.
+- Changing the `dotnet-todo` submodule.
+- Adding Telnet or WebSocket transports.
+
+## Pilot Command Surface
+
+| Route | Typed result | MCP behavior |
+|---|---|---|
+| `utilities date [--utc|-u]` | `DateResult` | `.ReadOnly()` |
+| `utilities guid` | `GuidResult` | `.ReadOnly()` |
+| `ip local` | list of `LocalIpAddressResult` | `.ReadOnly()` |
+| `hue bridges` | list of `HueBridgeResult` | `.ReadOnly().OpenWorld().LongRunning()` |
+| `hue lights [--ip|-i]` | list of `HueLightResult` | `.ReadOnly().OpenWorld().LongRunning()` |
+| `hue {light} on [--ip|-i] [--brightness|-b] [--color|-c]` | `HueActionResult` | `.OpenWorld().Idempotent().LongRunning()` |
+| `hue {light} off [--ip|-i]` | `HueActionResult` | `.OpenWorld().Idempotent().LongRunning()` |
+
+`{light}` accepts a numeric ID or case-insensitive name. Resolution lists lights through `IHueLightService`, then calls its existing `SetLight` operation.
+
+## Architecture
+
+`GuppiReplApp.Create(...)` creates one `ReplApp`, registers `Guppi.Core`, `TimeProvider.System`, and Repl.Spectre through DI, permits tests to append replacement registrations, mounts named module contexts, enables terminal, interactive, and CLI profiles, and calls `UseMcpServer()`.
+
+```text
+Guppi.Repl/
+  GuppiReplApp.cs
+  Program.cs
+  Skills/
+    UtilitiesModule.cs
+    IpModule.cs
+    HueModule.cs
+  Results/
+    UtilityResults.cs
+    NetworkResults.cs
+    HueResults.cs
+```
+
+Modules use static lambdas and handler-parameter DI. Handlers return serializable records. Errors use semantic Repl results instead of successful strings beginning with `Error:`.
+
+The pilot does not add Hue registration. It avoids synchronous `Console.ReadLine()` in MCP or test sessions and points users to the existing `guppi hue register` flow when registration is required.
+
+`WithCompletion("light", ...)` suggests Hue names and IDs in the interactive REPL. It keeps the default interactive-only scope because Hue discovery is too expensive and stateful to execute on every shell Tab.
+
+## Testing
+
+A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing`. Tests invoke the real graph and injected fakes for typed utility, IP, and Hue results, Hue name resolution, semantic errors, completion, and persistent REPL context navigation. Final smoke validation launches `mcp serve` over STDIO and verifies `tools/list`.
+
+## Packaging and CI
+
+`Guppi.Repl` is locally packable as `dotnet-guppi-repl` with tool command `guppi.repl`. It is added to `Guppi.slnx` for build and test coverage, but existing CI publication remains unchanged.
+
+## Acceptance Criteria
+
+- Original 128 tests remain green and pilot tests pass.
+- `Guppi.Repl` builds on .NET 10 with Repl `0.11.0-dev.181`.
+- Selected operations run from CLI and a persistent REPL session.
+- `mcp serve` exposes those operations from the same graph.
+- Successes return typed results; failures are semantic errors.
+- `hue kitchen on` resolves a light by name.
+- Existing executables receive no runtime behavior changes.
+- The pilot packs and installs locally as `dotnet-guppi-repl` and `guppi.repl`.

--- a/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
+++ b/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-15
 **Version:** 9.2.0 (unchanged)
-**Status:** Approved for implementation
+**Status:** Implemented and validated
 
 ## Overview
 
@@ -87,7 +87,7 @@ Guppi.Repl/
     HueResults.cs
 ```
 
-Modules use static lambdas and handler-parameter DI. Handlers return serializable records. Errors use semantic Repl results instead of successful strings beginning with `Error:`.
+Modules are resolved through `MapModule<T>()` and receive their dependencies through constructor injection. Handlers remain thin and return serializable records. This preserves deterministic `Repl.Testing` coverage despite `ReplTestHost` 0.11.0-dev.181 using its session provider rather than `app.Services` for handler-parameter DI. Failures surface as semantic Repl validation errors rather than successful strings beginning with `Error:`.
 
 The pilot does not add Hue registration. It avoids synchronous `Console.ReadLine()` in MCP or test sessions and points users to the existing `guppi hue register` flow when registration is required.
 
@@ -95,11 +95,11 @@ The pilot does not add Hue registration. It avoids synchronous `Console.ReadLine
 
 ## Testing
 
-A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing`. Tests invoke the real graph and injected fakes for typed utility, IP, and Hue results, Hue name resolution, semantic errors, completion, and persistent REPL context navigation. Final smoke validation launches `mcp serve` over STDIO and verifies `tools/list`.
+A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing`. Graph tests use injected fakes for typed utility, IP, and Hue results, Hue name resolution, semantic errors, and completion. Because `ReplTestHost` runs each command as a hosted invocation rather than preserving interactive context scope, persistent navigation is tested through one real redirected interactive loop. Final smoke validation launches `mcp serve` over STDIO, verifies `initialize`, `tools/list`, a real tool call, and JSON-only stdout.
 
 ## Packaging and CI
 
-`Guppi.Repl` is locally packable as `dotnet-guppi-repl` with tool command `guppi.repl`. It is added to `Guppi.slnx` for build and test coverage, but existing CI publication remains unchanged.
+`Guppi.Repl` is locally packable as `dotnet-guppi-repl` with tool command `guppi.repl`. The package includes the repository README and suppresses `NU5111` only for Playwright runtime `.ps1` payload files that are not NuGet install scripts. It is added to `Guppi.slnx` for build and test coverage, but existing CI publication remains unchanged. MCP uses an explicit allow-list for `utilities`, `ip`, and `hue` paths.
 
 ## Acceptance Criteria
 
@@ -111,3 +111,13 @@ A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing
 - `hue kitchen on` resolves a light by name.
 - Existing executables receive no runtime behavior changes.
 - The pilot packs and installs locally as `dotnet-guppi-repl` and `guppi.repl`.
+
+## Validation Notes
+
+- Release build succeeds with warnings treated as errors.
+- 128 historical tests and 11 pilot tests pass.
+- One-shot CLI JSON, interactive context navigation, Hue fake-backed mutations, and interactive completion are exercised.
+- MCP STDIO advertises exactly seven pilot tools and successfully executes `utilities_date` without non-JSON stdout.
+- Repl `0.11.0-dev.181` emits the optional `utc` MCP schema default as the string `"False"` while declaring a Boolean type; binding works, but clients should not rely on that prerelease default representation.
+- The locally packed tool installs and runs from an isolated tool path.
+- Global `dotnet format` currently reports unrelated historical line-ending, import, and encoding debt; both new projects pass isolated `dotnet format --verify-no-changes`.

--- a/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
+++ b/docs/superpowers/specs/2026-07-15-repl-pilot-design.md
@@ -87,7 +87,7 @@ Guppi.Repl/
     HueResults.cs
 ```
 
-Modules are resolved through `MapModule<T>()` and receive their dependencies through constructor injection. Handlers remain thin and return serializable records. This preserves deterministic `Repl.Testing` coverage despite `ReplTestHost` 0.11.0-dev.181 using its session provider rather than `app.Services` for handler-parameter DI. Failures surface as semantic Repl validation errors rather than successful strings beginning with `Error:`.
+Modules are resolved through `MapModule<T>()` and receive their dependencies through constructor injection. Because `MapModule<T>()` activates a module once, `HueModule` captures only `IServiceScopeFactory` and resolves a fresh transient `IHueLightService` for each handler and completion invocation. This isolates the mutable Hue provider during concurrent MCP calls. Handlers remain thin and return serializable records. This preserves deterministic `Repl.Testing` coverage despite `ReplTestHost` 0.11.0-dev.181 using its session provider rather than `app.Services` for handler-parameter DI. Failures surface as semantic Repl validation errors rather than successful strings beginning with `Error:`.
 
 The pilot does not add Hue registration. It avoids synchronous `Console.ReadLine()` in MCP or test sessions and points users to the existing `guppi hue register` flow when registration is required.
 
@@ -95,11 +95,11 @@ The pilot does not add Hue registration. It avoids synchronous `Console.ReadLine
 
 ## Testing
 
-A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing`. Graph tests use injected fakes for typed utility, IP, and Hue results, Hue name resolution, semantic errors, and completion. Because `ReplTestHost` runs each command as a hosted invocation rather than preserving interactive context scope, persistent navigation is tested through one real redirected interactive loop. Final smoke validation launches `mcp serve` over STDIO, verifies `initialize`, `tools/list`, a real tool call, and JSON-only stdout.
+A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing`. Graph tests use injected fakes for typed utility, IP, and Hue results, Hue name resolution, ambiguity handling, per-invocation service lifetime, cancellation propagation, semantic errors, and completion. Because `ReplTestHost` runs each command as a hosted invocation rather than preserving interactive context scope, persistent navigation is tested through one real redirected interactive loop. An automated process-level test launches `mcp serve` over STDIO, parses every stdout line as JSON, verifies `initialize`, the exact `tools/list` contract and annotations, and a real `utilities_date` call.
 
 ## Packaging and CI
 
-`Guppi.Repl` is locally packable as `dotnet-guppi-repl` with tool command `guppi.repl`. The package includes the repository README and suppresses `NU5111` only for Playwright runtime `.ps1` payload files that are not NuGet install scripts. It is added to `Guppi.slnx` for build and test coverage, but existing CI publication remains unchanged. MCP uses an explicit allow-list for `utilities`, `ip`, and `hue` paths.
+`Guppi.Repl` is locally packable as `dotnet-guppi-repl` with tool command `guppi.repl`. The package includes the repository README and suppresses `NU5111` only for Playwright runtime `.ps1` payload files that are not NuGet install scripts. It is added to `Guppi.slnx` for build and test coverage, but existing CI publication remains unchanged. MCP uses an exact allow-list containing only the seven approved command paths; future commands under `utilities`, `ip`, or `hue` are not exposed implicitly.
 
 ## Acceptance Criteria
 
@@ -115,9 +115,10 @@ A new `Guppi.Repl.Tests` project uses NUnit, FluentAssertions, and `Repl.Testing
 ## Validation Notes
 
 - Release build succeeds with warnings treated as errors.
-- 128 historical tests and 11 pilot tests pass.
+- 128 historical tests and 18 pilot tests pass.
 - One-shot CLI JSON, interactive context navigation, Hue fake-backed mutations, and interactive completion are exercised.
-- MCP STDIO advertises exactly seven pilot tools and successfully executes `utilities_date` without non-JSON stdout.
-- Repl `0.11.0-dev.181` emits the optional `utc` MCP schema default as the string `"False"` while declaring a Boolean type; binding works, but clients should not rely on that prerelease default representation.
+- An automated MCP STDIO test advertises exactly seven pilot tools, validates representative schemas and mutation annotations, successfully executes `utilities_date`, and rejects non-JSON stdout.
+- Repl `0.11.0-dev.181` does not unwrap nullable numeric types when generating MCP schemas and serializes parameter defaults as strings. The pilot therefore models optional brightness as an integer percentage with an internal `-1` omission sentinel and validates 0–100 before discovery. Repl still emits defaults such as `utc: "False"` and `brightness: "-1"`; binding works, but clients should not rely on those prerelease default representations.
+- Cancellation flows from Repl through Core into Hue discovery. Q42.HueApi does not expose cancellation for light reads or command sends, so Guppi checks cancellation before starting those calls and does not use `WaitAsync` to report cancellation while an already-started mutation continues.
 - The locally packed tool installs and runs from an isolated tool path.
 - Global `dotnet format` currently reports unrelated historical line-ending, import, and encoding debt; both new projects pass isolated `dotnet format --verify-no-changes`.


### PR DESCRIPTION
## Summary

Adds an **experimental, additive `Guppi.Repl` pilot** pinned to Repl Toolkit `0.11.0-dev.181`.

The pilot maps a deliberately small typed command graph once and exposes it through:

- one-shot CLI commands;
- a persistent interactive REPL;
- MCP STDIO via `guppi.repl mcp serve`.

The existing `guppi` and `guppi.mcp` applications and their publication workflows are unchanged.

### Pilot surface

- `utilities date [--utc|-u]`
- `utilities guid`
- `ip local`
- `hue bridges`
- `hue lights [--ip|-i]`
- `hue {light} on [--ip|-i] [--brightness|-b] [--color|-c]`
- `hue {light} off [--ip|-i]`

Hue brightness is a percentage from 0 to 100. Numeric light arguments match exact IDs first; case-insensitive names must be unique. Commands return stable typed records, include MCP behavioral annotations, and provide interactive-only dynamic Hue completion.

### MCP

`UseMcpServer()` exposes an exact allow-list of seven tools; future commands under the same contexts are not exposed implicitly:

- `utilities_date`
- `utilities_guid`
- `ip_local`
- `hue_bridges`
- `hue_lights`
- `hue_on`
- `hue_off`

### Post-review hardening

- Resolves a fresh transient Hue service/provider per handler and completion invocation, avoiding shared mutable bridge/client state across concurrent MCP calls.
- Propagates cancellation through Repl, Core, and cancellable Hue discovery; removes misleading `WaitAsync` cancellation around Q42 operations that cannot be cancelled.
- Prioritizes exact numeric IDs and rejects ambiguous duplicate names with candidate IDs.
- Models brightness as an MCP integer, validates 0–100 before discovery or mutation, and marks Hue mutations explicitly destructive, idempotent, and open-world.
- Adds a process-level MCP regression test covering initialization, exact tools, schemas, annotations, a real tool call, and JSON-only stdout.

### Packaging and documentation

- Adds locally packable `dotnet-guppi-repl` with tool command `guppi.repl`.
- Includes the repository README in the NuGet package.
- Adds `Guppi.Repl.Tests` and solution coverage.
- Documents commands, architecture, test-host limitations, MCP constraints, and non-publication scope.

## Validation

- `dotnet build Guppi.slnx -c Release --no-restore`
  - 0 warnings, 0 errors
- `dotnet test Guppi.slnx -c Release --no-build --no-restore`
  - 128/128 existing tests pass
  - 18/18 pilot tests pass
  - 146/146 total
- Targeted formatting passes on every changed C# file.
- One-shot CLI JSON and a real redirected interactive context loop pass.
- The packaged and isolated `dotnet-guppi-repl` 9.2.0 tool installs and runs successfully; its package includes README.
- Installed-package MCP STDIO validates `initialize`, exact `tools/list`, integer brightness schema, destructive annotations, a real `utilities_date` call, empty stderr, and JSON-only stdout.
- Dependency audit reports no known vulnerable packages in Core or Repl.
- Secret/scope diff review is clean.
- No `.github/workflows` or `dotnet-todo` changes.

## Intentional limitations / findings

- This is a vertical pilot, not a full migration and not a replacement for the existing heads.
- `MapModule<T>()` activates a module once. `HueModule` therefore captures only `IServiceScopeFactory` and resolves the mutable Hue service/provider per invocation.
- `ReplTestHost` `0.11.0-dev.181` uses its hosted session provider rather than `app.Services` for handler-parameter DI; persistent scope navigation is covered by a real interactive-loop test.
- Repl `0.11.0-dev.181` does not unwrap nullable numeric types when generating MCP schemas and serializes parameter defaults as strings. The pilot uses an integer brightness omission sentinel and validates 0–100; clients should not rely on prerelease defaults such as `utc: "False"` or `brightness: "-1"`.
- Q42.HueApi accepts cancellation for bridge discovery but not for light reads or command sends. Guppi checks cancellation before non-cancellable calls and completes an already-started mutation rather than reporting premature cancellation.
- Hue registration remains in the existing interactive `guppi hue register` flow; MCP never blocks on `Console.ReadLine()`.
- Global solution formatting still reports unrelated historical line-ending/import/encoding debt; formatting was scoped to changed files.
- Existing CI continues to publish only `dotnet-guppi` and `dotnet-guppi-mcp`.
